### PR TITLE
Modifying Dockerfile to run node as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:20-alpine AS development
+FROM node:21-alpine AS development
 ENV NODE_ENV development
 # Add a work directory
 WORKDIR /usr/app
+# copy files as a non-root user. The 'node' user is built in the Node image.
+RUN chown node:node ./
+USER node
 # Cache and Install dependencies
 COPY ./react-app/package.json .
 COPY ./react-app/package-lock.json .


### PR DESCRIPTION
Still not sure what the problem is, but trying to modify the dockerfile so that node does not run as root user. Looked like npm was trying to create directories in root in argoCD, so hopefully this will fix that.