### PR TITLE
Added chown of /tmp for node user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN chown -R node:node /usr
 RUN chown -R node:node /tmp
 USER node
 # Cache and Install dependencies
-COPY ./react-app/package.json .
-COPY ./react-app/package-lock.json .
+COPY --chown=node:node ./react-app/package.json .
+COPY --chown=node:node ./react-app/package-lock.json .
 RUN npm ci
 RUN npm install react-scripts -g
 # Copy app files
-COPY ./react-app/ .
+COPY --chown=node:node ./react-app/ .
 RUN npm run build
 
 # production environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 RUN chown -R node:node /app
 RUN chown -R node:node /usr
+RUN chown -R node:node /tmp
 USER node
 # Cache and Install dependencies
 COPY ./react-app/package.json .


### PR DESCRIPTION
Still getting errors in argoCD deployment, seems like cluster settings are blocking access in a bunch of places. Tried adding access of node user to /tmp as well as it complained about that in one of the error messages.