### PR TITLE
Trying to set up and use an npm package called matomo-tracker-react

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-app",
       "version": "0.1.0",
       "dependencies": {
+        "@datapunt/matomo-tracker-react": "^0.5.1",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2297,6 +2298,22 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@datapunt/matomo-tracker-js": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@datapunt/matomo-tracker-js/-/matomo-tracker-js-0.5.1.tgz",
+      "integrity": "sha512-9/MW9vt/BA5Db7tO6LqCeQKtuvBNjyq51faF3AzUmPMlYsJCnASIxcut3VqJKiribhUoey7aYbPIYuj9x4DLPA=="
+    },
+    "node_modules/@datapunt/matomo-tracker-react": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@datapunt/matomo-tracker-react/-/matomo-tracker-react-0.5.1.tgz",
+      "integrity": "sha512-lrNYM9hFL6XK0VAdtMb7MwZrLWhaAconx4c7gOGAMvoWuoVm+ZZIYFuKtfYdYMeBf0avxWtmKRwjZEg7T8jV2A==",
+      "dependencies": {
+        "@datapunt/matomo-tracker-js": "^0.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@datapunt/matomo-tracker-react": "^0.5.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/react-app/src/index.tsx
+++ b/react-app/src/index.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react'
 import './index.css';
 import App from './App';
+
+const instance = createInstance({
+  urlBase: 'https://matomo.dc.scilifelab.se/',
+  siteId: 9,
+  }
+)
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -9,5 +16,6 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <App />
+    <MatomoProvider value={instance} />
   </React.StrictMode>
 );


### PR DESCRIPTION
The automatically generated Matomo tracking script was not directly applicable to the Single Page App react setup, installed a package called @datapunt/matomo-tracker-react to set it up. Will need to push all the way to prod to test if it works however.