### PR TITLE
Fixed Routing issue, making it possible to load page routes directly without going through the index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /react-app/npm-debug.log*
 /react-app/yarn-debug.log*
 /react-app/yarn-error.log*
+react-app/public/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY ./react-app/ .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine
-RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf
-RUN sed -i 's/#error_page  404/error_page  404/' /etc/nginx/conf.d/default.conf
+USER 101
+COPY ./conf/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build /usr/share/nginx/html
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 8080;
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      try_files $uri $uri/ /index.html;
+    } 
+  }


### PR DESCRIPTION
Editing config in Dockerfile to fix an issue with React routing. When the React app
is built and run on the nginx image, by default only the index page (or "/" path) is
actually stored on the server. The other routed paths are handled by the client browser. As a result
you can visit the page and visit different paths while "in the app", but if you try to directly request
the adress of a path other than the index, you'll be met by 404. This change sends all requests
back to index, so if you visit "address.com/about" the server will send you back the root page + "/about"
as expected.