### PR TITLE
Menu item update

### DIFF
--- a/pmp-frontend-app/src/components/HeaderComponent.tsx
+++ b/pmp-frontend-app/src/components/HeaderComponent.tsx
@@ -63,7 +63,7 @@ export default function HeaderComponent() {
                 </Link>
             </div>
             <div className="navbar-center lg:flex">
-                <ul className="menu menu-horizontal text-xl">
+                <ul className="menu menu-horizontal text-lg mt-0.5">
                 {Object.keys(links).map( key => (
                     <li>{<NavLink className={links[key].classes} to={links[key].link}>{links[key].text}</NavLink>}</li>
                 ))}


### PR DESCRIPTION
Changed the size of the menu item text to text-lg instead of xl.
Moreover, I added a margin of 0.5rem to the top, so it aligns better with the end of the font height of the logo.