### PR TITLE
Work on adding KIARVA page in precision-medicine-portal

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,4 +5,5 @@ server {
       index  index.html index.htm;
       try_files $uri $uri/ /index.html;
     } 
+    add_header Content-Security-Policy "default-src 'self';" always;
   }

--- a/pmp-frontend-app/package-lock.json
+++ b/pmp-frontend-app/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-google-recaptcha": "^3.1.0",
+        "react-iframe": "^1.8.5",
         "react-markdown": "^9.0.1",
         "react-router-dom": "^6.22.3",
         "remark-gfm": "^4.0.0"
@@ -4728,6 +4729,17 @@
       },
       "peerDependencies": {
         "react": ">=16.4.1"
+      }
+    },
+    "node_modules/react-iframe": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/react-iframe/-/react-iframe-1.8.5.tgz",
+      "integrity": "sha512-F4cQJGs3ydaG6fJWfuz9yLwOU0Trzl6kttXuUG+vYwosH8enOOFxZWEDQCSbNVO8ayjfYZeqLxEvdvcsSy4GvA==",
+      "dependencies": {
+        "object-assign": "^4.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.x.x"
       }
     },
     "node_modules/react-is": {

--- a/pmp-frontend-app/package.json
+++ b/pmp-frontend-app/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-google-recaptcha": "^3.1.0",
+    "react-iframe": "^1.8.5",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.22.3",
     "remark-gfm": "^4.0.0"

--- a/pmp-frontend-app/src/components/Routes.tsx
+++ b/pmp-frontend-app/src/components/Routes.tsx
@@ -13,6 +13,7 @@ import AboutFAQPage from '../pages/AboutFAQPage';
 import AboutTeamPage from '../pages/AboutTeamPage';
 import AboutPartnersPage from '../pages/AboutPartnersPage';
 import AccessClinicalDataPage from '../pages/AccessClinicalDataPage'
+import KiarvaIFramePage from '../pages/KiarvaIFramePage';
 
 const router = createBrowserRouter([
     {
@@ -72,6 +73,10 @@ const router = createBrowserRouter([
             {
                 path: 'privacy',
                 element: <PrivacyPage />,
+            },
+            {
+                path: 'kiarva',
+                element: <KiarvaIFramePage />,
             },
         ]
     },

--- a/pmp-frontend-app/src/pages/KiarvaIFramePage.tsx
+++ b/pmp-frontend-app/src/pages/KiarvaIFramePage.tsx
@@ -1,0 +1,21 @@
+import { ReactElement } from 'react';
+import { TrackPageViewIfEnabled } from '../util/cookiesHandling';
+import Iframe from 'react-iframe';
+
+export default function KiarvaIFramePage(): ReactElement {
+    TrackPageViewIfEnabled();
+
+    let kiarva_hostname = '';
+
+    return (
+        <>
+            {kiarva_hostname &&
+            (<Iframe 
+            url={kiarva_hostname}
+            width="100%" 
+            height="1000" 
+            allow='modals scripts' />)
+            }
+        </>
+    );
+}


### PR DESCRIPTION
Added page with iframe that will eventually show kiarva page, disabled for now since the page isn't up. Disabled other pages using precision-medicine-portal in a frame through content-security-policy on build.

Once the actual KIARVA page is up we can add the hostname and easily show it, however we'll probably need to fiddle with the layout settings a bit in the iframe component.