### PR TITLE
Remove arrow button & added registry page

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.7",
         "cookies-next": "^4.2.1",
         "daisyui": "^4.12.10",
+        "dompurify": "^3.1.7",
         "js-cookie": "^3.0.5",
         "next": "14.2.11",
         "react": "^18",
@@ -22,6 +23,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^20.16.5",
         "@types/react": "^18",
@@ -489,6 +491,16 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -587,6 +599,13 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1698,6 +1717,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.7.7",
     "cookies-next": "^4.2.1",
     "daisyui": "^4.12.10",
+    "dompurify": "^3.1.7",
     "js-cookie": "^3.0.5",
     "next": "14.2.11",
     "react": "^18",
@@ -23,6 +24,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^20.16.5",
     "@types/react": "^18",

--- a/next-app/src/app/accessclinicaldata/page.tsx
+++ b/next-app/src/app/accessclinicaldata/page.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
 import { ReactElement } from "react";
-import { BODY_CLASSES } from '@/constants'
-import Link from 'next/link';
+import { BODY_CLASSES } from "@/constants";
+import Link from "next/link";
 import { ILink } from "@/interfaces/types";
-import { TrackPageViewIfEnabled } from '@/util/cookiesHandling';
+import { TrackPageViewIfEnabled } from "@/util/cookiesHandling";
 
 export default function AboutPage(): ReactElement {
   TrackPageViewIfEnabled();
@@ -17,23 +17,19 @@ export default function AboutPage(): ReactElement {
   return (
     <div className={BODY_CLASSES}>
       <div className="text-sm breadcrumbs">
-          <ul>
-          {Object.keys(breadcrumbs).map( key => (
-              <li key={key}>
-                  {
-                  breadcrumbs[key].link 
-                      ? 
-                      <Link href={breadcrumbs[key].link}>
-                          {breadcrumbs[key].text}
-                      </Link> 
-                      : 
-                      <>
-                          {breadcrumbs[key].text}
-                      </>
-                  }
-              </li>
+        <ul>
+          {Object.keys(breadcrumbs).map((key) => (
+            <li key={key}>
+              {breadcrumbs[key].link ? (
+                <Link href={breadcrumbs[key].link}>
+                  {breadcrumbs[key].text}
+                </Link>
+              ) : (
+                <>{breadcrumbs[key].text}</>
+              )}
+            </li>
           ))}
-          </ul>
+        </ul>
       </div>
       {/* Paragraph before the first heading */}
       <p>
@@ -50,18 +46,6 @@ export default function AboutPage(): ReactElement {
       {/* The first heading */}
       <div className="flex items-center">
         <h1 className="text-2xl my-2">Patient records and medical records</h1>
-        <Link href="/patient-records">
-          <svg
-            className="ml-2 fill-primary w-7 h-7"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 32 32"
-          >
-            <g data-name="19-Arrow Right">
-              <path d="M16 0a16 16 0 1 0 16 16A16 16 0 0 0 16 0zm0 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14z" />
-              <path d="m26.71 15.29-7-7-1.42 1.42 5.3 5.29H5v2h18.59l-5.29 5.29 1.41 1.41 7-7a1 1 0 0 0 0-1.41z" />
-            </g>
-          </svg>
-        </Link>
       </div>
       {/* Paragraph under the first heading */}
       <p>

--- a/next-app/src/app/registries/PageClient.tsx
+++ b/next-app/src/app/registries/PageClient.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import DOMPurify from "dompurify";
+import { RegistrySources, RegistrySourcesFilters } from "@/interfaces/types";
+
+const filters: RegistrySourcesFilters = {
+  registryCentre: [
+    "Kvalitetsregistercentrum Stockholm",
+    "Registercentrum Syd",
+    "Registercentrum Norr",
+    "Uppsala Clinical Research Center",
+    "Registercentrum Västra Götaland",
+    "Registercentrum Sydost",
+    "RCC Stockholm Gotland",
+    "RCC Sydöst",
+    "RCC Norr",
+    "RCC Mellansverige",
+    "RCC Väst",
+    "RCC Syd",
+  ],
+  registryCategory: [
+    "National quality registry",
+    "Other quality registry",
+    "National cancer quality registry",
+  ],
+};
+
+const organisationLinks: { [key: string]: string } = {
+  "Kvalitetsregistercentrum Stockholm": "https://qrcstockholm.se",
+  "Registercentrum Syd": "https://registercentrum.se",
+  "Registercentrum Norr": "https://rcnorr.se",
+  "Uppsala Clinical Research Center": "https://www.ucr.uu.se/sv/",
+  "Registercentrum Västra Götaland": "https://registercentrum.se",
+  "Registercentrum Sydost":
+    "https://sydostrasjukvardsregionen.se/samverkansgrupper/data-och-analys/registercentrum-sydost/",
+  "RCC Stockholm Gotland": "https://cancercentrum.se/stockholm-gotland/",
+  "RCC Sydöst": "https://cancercentrum.se/sydost/",
+  "RCC Norr": "https://cancercentrum.se/norr/",
+  "RCC Mellansverige": "https://cancercentrum.se/mellansverige/",
+  "RCC Väst": "https://cancercentrum.se/vast/",
+  "RCC Syd": "https://cancercentrum.se/syd/",
+};
+
+export default function DataPageClient({
+  initialData,
+}: {
+  initialData: RegistrySources[];
+}) {
+  const [RegistrySourcesJSON, setRegistrySourcesJSON] =
+    useState<RegistrySources[]>(initialData);
+  const [selectedFilters, setSelectedFilters] =
+    useState<RegistrySourcesFilters>({
+      registryCentre: [],
+      registryCategory: [],
+    });
+  const searchParams = useSearchParams();
+  const searchBar = searchParams.get("search") || "";
+
+  const [checkedList, setCheckedList] = useState<boolean[]>(
+    Array(filters.registryCentre.length + filters.registryCategory.length).fill(
+      false
+    )
+  );
+
+  const handleFilterChange = (
+    type: keyof RegistrySourcesFilters,
+    value: string,
+    index: number
+  ) => {
+    setSelectedFilters((prev) => {
+      const updated = { ...prev };
+      updated[type] = updated[type].includes(value)
+        ? updated[type].filter((item) => item !== value)
+        : [...updated[type], value];
+      return updated;
+    });
+    setCheckedList((prev) =>
+      prev.map((item, idx) => (idx === index ? !item : item))
+    );
+  };
+
+  const applyFilters = (data: RegistrySources) => {
+    const matchesCentre =
+      !selectedFilters.registryCentre.length ||
+      selectedFilters.registryCentre.some((filter) =>
+        data.registry_centre.some(
+          (centre) => centre.toLowerCase() === filter.toLowerCase()
+        )
+      );
+    const matchesCategory =
+      !selectedFilters.registryCategory.length ||
+      selectedFilters.registryCategory.some((filter) =>
+        data.category.some((cat) => cat.toLowerCase() === filter.toLowerCase())
+      );
+    const matchesSearch = searchBar
+      .toLowerCase()
+      .split(" ")
+      .every(
+        (tag) =>
+          data.name.toLowerCase().includes(tag) ||
+          data.search_tags.some((st) => st.toLowerCase().includes(tag))
+      );
+    return matchesCentre && matchesCategory && matchesSearch;
+  };
+
+  return (
+    <div className="container mx-auto p-4 pt-16">
+      <div className="flex flex-col lg:flex-row gap-16">
+        {/* Left Column */}
+        <div className="space-y-6 w-full lg:w-1/4">
+          <div>
+            <label className="font-bold text-xl block mb-2">Search</label>
+            <input
+              type="text"
+              placeholder="Name/Keywords"
+              className="input bg-neutral input-bordered border-neutral rounded-[10px] w-full"
+              value={searchBar}
+              onChange={(e) => {
+                const params = new URLSearchParams(window.location.search);
+                params.set("search", e.target.value);
+                window.history.replaceState(
+                  {},
+                  "",
+                  `${window.location.pathname}?${params}`
+                );
+              }}
+            />
+          </div>
+          <div>
+            <h2 className="font-bold text-xl block mb-2">Organisation</h2>
+            <div className="form-control w-full rounded-[10px] shadow border-2 border-neutral p-3">
+              {filters.registryCentre.map((centre, idx) => (
+                <div key={centre} className="flex flex-row">
+                  <label className="label cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="checkbox border-gray-300 [--chkbg:theme(colors.primary)] [--chkfg:white]"
+                      onChange={() =>
+                        handleFilterChange("registryCentre", centre, idx)
+                      }
+                      checked={checkedList[idx]}
+                    />
+                  </label>
+                  <span className="label-text text-neutral-content pt-2.5 pl-2">
+                    {centre}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <h2 className="font-bold text-xl block mb-2">Category</h2>
+            <div className="form-control w-full rounded-[10px] shadow border-2 border-neutral p-3">
+              {filters.registryCategory.map((category, idx) => (
+                <div key={category} className="flex flex-row">
+                  <label className="label cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="checkbox border-gray-300 [--chkbg:theme(colors.primary)] [--chkfg:white]"
+                      onChange={() =>
+                        handleFilterChange(
+                          "registryCategory",
+                          category,
+                          filters.registryCentre.length + idx
+                        )
+                      }
+                      checked={checkedList[filters.registryCentre.length + idx]}
+                    />
+                  </label>
+                  <span className="label-text text-neutral-content pt-2.5 pl-2">
+                    {category}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="form-control rounded-[10px] shadow border-2 border-neutral bg-neutral p-2 mt-8">
+            <div className="flex items-center mb-1">
+              <div className="mr-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  className="h-4 w-4 text-neutral-content"
+                >
+                  <g data-name="26.Information">
+                    <path d="M12 24a12 12 0 1 1 12-12 12.013 12.013 0 0 1-12 12zm0-22a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2z" />
+                    <path d="M15 19h-4v-8H9V9h4v8h2v2zM11 5h2v2h-2z" />
+                  </g>
+                </svg>
+              </div>
+              <span className="font-bold text-neutral-content">
+                Please note:
+              </span>
+            </div>
+            <div className="text-justify text-black text-sm">
+              <p>
+                The collected data in most of the registries is only available
+                in Swedish.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Right Column */}
+        <div className="w-full lg:w-3/4">
+          <div className="flex flex-col space-y-6 col-span-2">
+            {RegistrySourcesJSON.filter(applyFilters).map((item, index) => (
+              <div
+                key={index}
+                className={`form-control rounded-[10px] shadow border-2 border-neutral ${
+                  index !== 0 ? "mb-6" : ""
+                }`}
+              >
+                <div className="bg-neutral p-3 flow-root rounded-t-[8px] pr-4">
+                  <a
+                    href={DOMPurify.sanitize(item.url)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-neutral-content text-xl"
+                  >
+                    {item.name}
+                  </a>
+                </div>
+                <div className="p-3">
+                  <p className="text-black text-justify">
+                    {item.Information || "Information not available."}
+                  </p>
+                  <div className="mt-3 flex flex-row space-x-2">
+                    {/* Start Year */}
+                    <div className="flex-shrink-0 px-3 py-1 bg-black opacity-80 text-white rounded-lg shadow-sm">
+                      <strong className="text-xs block">Start year:</strong>
+                      <p className="text-xs leading-tight">{item.start_date}</p>
+                    </div>
+
+                    {/* Organisation */}
+                    <div className="flex-shrink-0 px-3 py-1 bg-black opacity-80 text-white rounded-lg shadow-sm">
+                      <strong className="text-xs block">Organisation:</strong>
+                      <a
+                        href={DOMPurify.sanitize(
+                          organisationLinks[item.registry_centre[0]]
+                        )}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs block hover:underline"
+                        style={{
+                          textDecoration: "none",
+                          cursor: "pointer",
+                          margin: 0,
+                          padding: 0,
+                        }}
+                      >
+                        {item.registry_centre.join(", ")}
+                      </a>
+                    </div>
+
+                    {/* Category */}
+                    <div className="flex-shrink-0 px-3 py-1 bg-black opacity-80 text-white rounded-lg shadow-sm">
+                      <strong className="text-xs block">Category:</strong>
+                      <p className="text-xs leading-tight">
+                        {item.category.join(", ")}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next-app/src/app/registries/PageClient.tsx
+++ b/next-app/src/app/registries/PageClient.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useSearchParams } from "next/navigation";
-import DOMPurify from "dompurify";
 import { RegistrySources, RegistrySourcesFilters } from "@/interfaces/types";
 
 const filters: RegistrySourcesFilters = {
@@ -48,8 +47,7 @@ export default function DataPageClient({
 }: {
   initialData: RegistrySources[];
 }) {
-  const [RegistrySourcesJSON, setRegistrySourcesJSON] =
-    useState<RegistrySources[]>(initialData);
+  const [RegistrySourcesJSON] = useState<RegistrySources[]>(initialData);
   const [selectedFilters, setSelectedFilters] =
     useState<RegistrySourcesFilters>({
       registryCentre: [],
@@ -215,7 +213,7 @@ export default function DataPageClient({
               >
                 <div className="bg-neutral p-3 flow-root rounded-t-[8px] pr-4">
                   <a
-                    href={DOMPurify.sanitize(item.url)}
+                    href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-neutral-content text-xl"
@@ -238,9 +236,7 @@ export default function DataPageClient({
                     <div className="flex-shrink-0 px-3 py-1 bg-black opacity-80 text-white rounded-lg shadow-sm">
                       <strong className="text-xs block">Organisation:</strong>
                       <a
-                        href={DOMPurify.sanitize(
-                          organisationLinks[item.registry_centre[0]]
-                        )}
+                        href={organisationLinks[item.registry_centre[0]]}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-xs block hover:underline"

--- a/next-app/src/app/registries/page.tsx
+++ b/next-app/src/app/registries/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from "react";
+import DataPageClient from "./PageClient";
+import registryData from "@/assets/Kvalitetsregister_geo_dates_02.09.2024.json";
+
+export const metadata = {
+  title: "Registries",
+  description: "Registry information",
+};
+
+async function getRegistryData() {
+  // In a real-world scenario, you might fetch this data from an API
+  // For now, we'll use the imported JSON data
+  const updatedRegistryData = registryData.map((entry) => ({
+    ...entry,
+    start_date: entry.start_date ? entry.start_date.split("-")[0] : "",
+    category: entry.category || [],
+  }));
+  return updatedRegistryData;
+}
+
+export default async function DataPage() {
+  const registryData = await getRegistryData();
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <DataPageClient initialData={registryData} />
+    </Suspense>
+  );
+}

--- a/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
+++ b/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
@@ -1,0 +1,2387 @@
+[
+    {
+        "name": "Barnobesitasregister i Sverige – BORIS",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://www.e-boris.se/",
+        "search_tags": [
+            "BORIS",
+            "childhood obesity",
+            "Sverige",
+            "obesity"
+        ],
+        "Information": "One of the world's largest and oldest registries for the treatment of childhood obesity. BORIS was established in 2005 and has over 40,000 registered individuals. In more than 40 scientific publications, BORIS has contributed to increased knowledge about childhood obesity.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2005"
+    },
+    {
+        "name": "Endovaskulär behandling av Stroke – EVAS-registret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://www.evas-registret.se/",
+        "search_tags": [
+            "stroke",
+            "endovascular",
+            "stroke",
+            "Endovaskulär"
+        ],
+        "Information": "EVAS is, a government funded national quality registry in Sweden for endovascular stroke treatment with full transparency in every aspect. It is based on a modern, top-of-the-line data platform and works in close relationship and shares data with RIKS-STROKE, which is the equivalent for all stroke patients in the country.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2012"
+    },
+    {
+        "name": "Graviditetsregistret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.medscinet.com/gr/default.aspx",
+        "search_tags": [
+            "Graviditetsregistret",
+            "baby",
+            "prenatal",
+            "postnatal",
+            "fetal",
+            "neonatal"
+        ],
+        "Information": "The purpose of the registry is to provide a solid foundation of data and results for healthcare services across the country. Data is collected from maternal healthcare, fetal diagnostics and delivery records. As of 2024, the registry includes data on roughly 58,500 pregnant individuals and about 63,600 deliveries.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "InfCareHIV",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://infcarehiv.se/",
+        "search_tags": [
+            "HIV",
+            "InfCareHIV",
+            "immune",
+            "virus"
+        ],
+        "Information": "Includes all HIV clinics in Sweden, covering over 99% of those diagnosed with HIV. Key data collected at enrollment and follow-up include sex at birth, gender identity, transmission route, HIV RNA levels, CD4+ cell counts, drug resistance, and co-infections with hepatitis C and B. Medication start/stop dates, AIDS diagnoses, and causes of death are also recorded.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1983"
+    },
+    {
+        "name": "InfCareHepatit",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://www.infcarehepatit.se/",
+        "search_tags": [
+            "liver",
+            "hepatitis",
+            "virus",
+            "InfCareHepatit"
+        ],
+        "Information": "InfCareHepatit is a Swedish registry that includes individuals with Hepatitis B and C. It involves all infectious disease clinics in Sweden and one gastroenterology clinic, covering over 90% of Hepatitis C patients and a majority of those with Hepatitis B. The registry collects data on age, gender at birth, country of birth, virus type, viral load, transmission route, date of first positive Hepatitis B or C test, liver function tests, and fibrosis assessment results. For those receiving treatment, it also records medication type, treatment outcomes, and any complications such as liver cirrhosis or cancer.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Kvalitetsregister för cystisk fibros – CF-registret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://cf-registret.se/",
+        "search_tags": [
+            "lungs",
+            "cystic fibrosis",
+            "CF-registret"
+        ],
+        "Information": "The aim is to enhance the quality of care, survival rates, and quality of life for all cystic fibrosis (CF) patients in Sweden. It was established as a national quality registry in 2012. Since its inception, the purpose of the registry has been to continuously monitor all individuals with CF over time and ensure equitable and fair care throughout Sweden. The registry is utilised by the four CF centres in Sweden as well as some regional hospitals that treat CF patients.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2012"
+    },
+    {
+        "name": "Nationellt kvalitetsregister för assisterad befruktning – Q-IVF",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.medscinet.com/qivf/",
+        "search_tags": [
+            "reproduction",
+            "assisted reproduction",
+            "medscinet"
+        ],
+        "Information": "This registry is jointly managed by all IVF clinics in Sweden. The purpose of the registry is to continuously monitor treatment outcomes and any medical risks for both IVF children and the treated couples or women. It also provides participating clinics with data to support their development and quality improvement efforts.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "Svenska hemofiliregistret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://svenskahemofiliregistret.se/",
+        "search_tags": [
+            "hemophilia",
+            "bleeding",
+            "blood",
+            "hemofiliregistret"
+        ],
+        "Information": "Aims to effectively monitor this specific group of patients who often receive lifelong treatment, with the goal of enhancing the quality of care. Key metrics for assessing the effectiveness of the treatment include the annual number of bleeding episodes and joint damage. Joint damage is a long-term consequence of past joint bleeding and is evaluated through functional assessments using joint scores.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2015"
+    },
+    {
+        "name": "Svenska Intensivvårdsregistret – SIR",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.icuregswe.org/",
+        "search_tags": [
+            "SIR",
+            "Intensivvårdsregistret",
+            "intensive care",
+            "Svenska"
+        ],
+        "Information": "SIR aims to monitor and improve the quality of intensive care in Sweden within selected areas that are continuously tracked. Additionally, SIR aims to support the development of methods and research in intensive care, particularly in the field of epidemiology, as well as in other specific areas where collaboration among multiple centers is essential for conducting high-quality scientific studies.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Svenska korsbandsregistret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.aclregister.nu/",
+        "search_tags": [
+            "ACL",
+            "korsbandsregistret"
+        ],
+        "Information": "This registry collects data on anterior cruciate ligament injuries and treatments across Sweden. Its purpose is to improve patient care by tracking surgical techniques, outcomes, and rehabilitation, as well as supporting research and benchmarking clinical practices.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2005-05-01"
+    },
+    {
+        "name": "Svenska neuroregister",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.neuroreg.se/",
+        "search_tags": [
+            "neuroregister",
+            "nervous system",
+            "neurological treatments",
+            "Svenska"
+        ],
+        "Information": "The Swedish Neuro Register gathers data on patients with neurological diseases such as multiple sclerosis, Parkinson's disease, epilepsy, and neuromuscular disorders. It aims to enhance the quality of care by monitoring treatment outcomes and supporting research into these conditions.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2001"
+    },
+    {
+        "name": "Svensk Reumatologis Kvalitetsregister – SRQ",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://srq.nu/",
+        "search_tags": [
+            "arthritis",
+            "rheumatic disease",
+            "SRQ"
+        ],
+        "Information": "This registry focuses on patients with rheumatic diseases like rheumatoid arthritis and ankylosing spondylitis. It collects data on disease activity, treatments, and patient outcomes to improve care quality and facilitate research into better management strategies.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1995"
+    },
+    {
+        "name": "Svenskt neonatalt kvalitetsregister – SNQ",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://www.medscinet.com/pnq/",
+        "search_tags": [
+            "newborn",
+            "neonatal care",
+            "neonatalt",
+            "SNQ"
+        ],
+        "Information": "he SNQ collects extensive data on all newborns admitted to neonatal intensive care units (NICUs) in Sweden. This includes demographic information, birth details, diagnoses, treatments, complications, and outcomes. The data covers a wide range of neonatal conditions and interventions, such as respiratory support, infections, congenital anomalies, and more..",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2001"
+    },
+    {
+        "name": "InfCare Sprututbyte",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://infcare.com/",
+        "search_tags": [
+            "Sprututbyte",
+            "needle exchange",
+            "harm reduction",
+            "InfCare"
+        ],
+        "Information": "This registry is part of the InfCare system and collects data on individuals participating in needle exchange programs. This includes demographic details, health status, risk behaviours, and testing for infectious diseases like HIV and hepatitis. The registry also tracks the provision of services such as counselling, vaccinations, and referrals to healthcare or social services.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2016"
+    },
+    {
+        "name": "Nationellt register för levertransplantation",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://www.swepharm.se/",
+        "search_tags": [
+            "liver transplant",
+            "levertransplantatation"
+        ],
+        "Information": "This registry collects detailed information on all liver transplant procedures performed in Sweden, including data on donor and recipient characteristics, surgical techniques, post-transplant complications, immunosuppression protocols, and long-term follow-up outcomes such as graft survival and patient survival.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "1998"
+    },
+    {
+        "name": "Lungfibrosregistret",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "http://slmf.se/kvalitetsregister/lungfibrosregistret/",
+        "search_tags": [
+            "fibrosis",
+            "Lungfibrosregistret",
+            "lung",
+            "pulmonary"
+        ],
+        "Information": "The register collects data on patients diagnosed with pulmonary fibrosis, including patient demographics, diagnostic criteria, disease severity, treatment regimens, pulmonary function tests, and patient-reported outcomes. It also tracks disease progression and responses to different therapies over time. It aims to include data from all healthcare providers treating patients with pulmonary fibrosis in Sweden, covering both university hospitals and regional clinics. ",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2014"
+    },
+    {
+        "name": "Svenskt kvalitetsregister för atopiskt dermatit – SwedAD",
+        "registry_centre": [
+            "Kvalitetsregistercentrum Stockholm"
+        ],
+        "url": "https://swedad.nu/",
+        "search_tags": [
+            "skin",
+            "SwedAD",
+            "eczema",
+            "atopic dermatitis"
+        ],
+        "Information": "SwedAD collects detailed data on patients with atopic dermatitis, including demographic information, disease severity, treatment regimens, and patient-reported outcomes such as quality of life and symptom control. It also includes information on healthcare resource utilisation, like hospital visits and medications. It includes data from both specialised care centres and general practitioners.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2019"
+    },
+    {
+        "name": "Amputations- och Protesregistret Swedeamp",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.swedeamp.com/",
+        "search_tags": [
+            "amputation",
+            "swedeamp",
+            "prosthetic",
+            "limb"
+        ],
+        "Information": "SwedeAmp collects information on patients undergoing amputations and those fitted with prosthetics. This includes details on the type of amputation, surgical techniques, prosthetic fittings, complications, and rehabilitation outcomes. The registry also tracks patient-reported outcomes related to mobility, function, and quality of life. The registry includes data from all healthcare providers in Sweden that perform amputations and provide prosthetic services, ensuring nationwide coverage",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "Barnkataraktregistret PECARE",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/pecare",
+        "search_tags": [
+            "paediatric",
+            "PECARE",
+            "eye",
+            "cataract"
+        ],
+        "Information": "PECARE focuses on children with cataracts, collecting data on diagnosis, surgical treatments, visual outcomes, and follow-up care. It also tracks complications and the use of visual aids post-surgery. The registry aims to improve understanding and management of paediatric cataracts in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2006"
+    },
+    {
+        "name": "BPSD – Svenskt register för Beteendemässiga och Psykiska Symptom vid Demens",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.bpsd.se/",
+        "search_tags": [
+            "BPSD",
+            "dementia",
+            "psychological",
+            "demens"
+        ],
+        "Information": "The BPSD register collects data on individuals with dementia who exhibit behavioural and psychological symptoms. It includes information on symptom types and severity, pharmacological and non-pharmacological treatments, and care plans. The registry aims to improve the management of dementia-related symptoms and enhance patient care.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "CPUP – Uppföljningsprogram för Cerebral Pares",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://cpup.se/",
+        "search_tags": [
+            "treatment",
+            "palsy",
+            "cerebral palsy",
+            "cpup"
+        ],
+        "Information": "CPUP collects comprehensive data on individuals with cerebral palsy, including demographic information, motor function, associated conditions, interventions, and outcomes. It tracks long-term development and care needs, with an emphasis on preventing complications and improving quality of life. The program covers all children and adults with cerebral palsy in Sweden who receive specialised care.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "HAKIR – Handkirurgiskt kvalitetsregister",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://hakir.se/",
+        "search_tags": [
+            "hand",
+            "HAKIR",
+            "surgery",
+            "reconstruction"
+        ],
+        "Information": "HAKIR gathers data on patients undergoing hand surgery, including surgical details, complications, rehabilitation processes, and functional outcomes. It also collects patient-reported outcomes related to hand function and quality of life, which are crucial for assessing the success of various surgical procedures.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "Könsdysforiregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/konsdysforiregistret",
+        "search_tags": [
+            "dysphoria",
+            "gender",
+            "identity",
+            "Könsdysforiregistret"
+        ],
+        "Information": "This registry collects data on individuals undergoing assessment and treatment for gender dysphoria, including demographic information, psychological evaluations, medical and surgical treatments, and follow-up outcomes. It aims to monitor the quality of care provided to individuals with gender dysphoria and to support research in this field.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2017"
+    },
+    {
+        "name": "LKG-registret – Nationellt kvalitetsregister för läpp- käk- och/eller gomspalt",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.lkg-registret.se/",
+        "search_tags": [
+            "cleft lip",
+            "lip",
+            "palate"
+        ],
+        "Information": "Contains data on patients born with cleft lip, cleft palate, or both. It includes information on diagnosis, surgical interventions, follow-up care, speech and language outcomes, dental health, and psychosocial aspects. Data on patient demographics, types of clefts, and the timing and types of surgical procedures are also gathered. It has national coverage and includes data from all specialist centres in Sweden that treat cleft lip and palate. ",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "MMCUP – Kvalitetsregister för MMC (myelomeningocele) och annan neuralrörsdefekt",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://mmcup.se/",
+        "search_tags": [
+            "MMCUP",
+            "myelomeningocele",
+            "neural tube defect"
+        ],
+        "Information": "This registry collects data on patients with myelomeningocele (spina bifida) and other neural tube defects. It includes information on surgical interventions, neurological function, urological and orthopaedic outcomes, associated conditions, and patient-reported outcomes related to quality of life. It captures data on approximately 95% of all cases in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "Nationella Kataraktregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.kataraktreg.se/",
+        "search_tags": [
+            "eye",
+            "vision",
+            "cataract"
+        ],
+        "Information": " The register gathers comprehensive data on cataract surgeries performed in Sweden, including patient demographics, types of cataract, surgical techniques, intraocular lenses used, complications, and visual outcomes. This registry covers over 99% of all cataract surgeries in Sweden, including data from all ophthalmology clinics and hospitals performing these procedures.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1992"
+    },
+    {
+        "name": "Nationella Kvalitetsregistret för Infektionssjukdomar",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.infektionsregistret.se/",
+        "search_tags": [
+            "pathogen",
+            "infectious disease",
+            "infectious",
+            "infektionsregistret"
+        ],
+        "Information": "This registry collects data on patients diagnosed with various infectious diseases, including HIV, hepatitis, and tuberculosis. Information includes demographics, diagnostics, treatments, disease progression, and outcomes, as well as data on antimicrobial resistance and healthcare-associated infections. It covers most patients with infectious diseases treated in hospitals and clinics. ",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "RIKSHÖFT",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://rikshoft.se/",
+        "search_tags": [
+            "RIKSHÖFT",
+            "fracture",
+            "hip",
+            "bone"
+        ],
+        "Information": "gathers data on patients with hip fractures, including demographic details, fracture types, treatments (surgical and non-surgical), complications, rehabilitation, and functional outcomes such as mobility and pain. It covers nearly all hospitals in Sweden that treat hip fractures, with around 90% of cases included in the registry.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1988"
+    },
+    {
+        "name": "SKaPa – Svenskt kvalitetsregister för Karies och Parodontit",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.skapareg.se/",
+        "search_tags": [
+            "Parodontit",
+            "dental caries",
+            "SKaPa",
+            "periodontitis"
+        ],
+        "Information": "SKaPa collects data on dental health, focusing on caries (tooth decay) and periodontitis (gum disease). Information includes dental examinations, treatment methods, preventive measures, and outcomes.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "SKRS – Svenskt Kvalitetsregister för Rehabilitering vid Synnedsättning",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/skrs",
+        "search_tags": [
+            "Synnedsättning",
+            "vision rehabilitation",
+            "eyesight"
+        ],
+        "Information": "SKRS collects data on individuals undergoing rehabilitation for visual impairment, including types of visual impairments, rehabilitation interventions, assistive devices used, and functional outcomes. The register includes data from all vision rehabilitation centres across Sweden, aiming for complete national coverage",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2015"
+    },
+    {
+        "name": "SQRTPA – Scandinavian Quality Register for Thyroid, Parathyroid and Adrenal surgery",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://sqrtpa.se/",
+        "search_tags": [
+            "parathyroid",
+            "thyroid",
+            "Adrenal",
+            "endocrine"
+        ],
+        "Information": "Data on patients undergoing surgery on the thyroid, parathyroid, or adrenal glands. It includes patient demographics, diagnoses, surgical details, pathology results, complications, and long-term outcomes. The registry includes data from major hospitals and surgical centres in Sweden, as well as in other Scandinavian countries.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2004"
+    },
+    {
+        "name": "Svenska Cornearegistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/cornea",
+        "search_tags": [
+            "transplant",
+            "corneal",
+            "Cornearegistret",
+            "vision"
+        ],
+        "Information": "Collects data on corneal surgeries, including corneal transplants. It tracks patient demographics, surgical techniques, donor and recipient details, complications, and visual outcomes. The registry includes data from all ophthalmology departments performing corneal surgeries in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1996"
+    },
+    {
+        "name": "Svenska Nationella Fotledsregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.swedankle.se/",
+        "search_tags": [
+            "orthopedics",
+            "surgery",
+            "ankle",
+            "ankle surgery"
+        ],
+        "Information": "Data on ankle surgeries, including fracture types, surgical techniques, complications, rehabilitation, and functional outcomes such as mobility and pain.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1997"
+    },
+    {
+        "name": "Svenska Makularegistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://makulareg.se/",
+        "search_tags": [
+            "macular",
+            "eye",
+            "retina",
+            "macular diseases"
+        ],
+        "Information": "The registry gathers data on patients with macular diseases, such as age-related macular degeneration (AMD). It includes information on diagnosis, treatments (especially anti-VEGF injections), visual outcomes, and patient-reported outcomes. Includes data from all ophthalmology clinics treating macular diseases in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Svenska Skulder- och Armbågsregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/ssar",
+        "search_tags": [
+            "shoulder and elbow",
+            "Armbågsregistret",
+            "shoulder"
+        ],
+        "Information": "Data on shoulder and elbow surgeries, including patient demographics, diagnoses, surgical procedures, rehabilitation, complications, and outcomes such as range of motion and pain.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1999"
+    },
+    {
+        "name": "SweTrau – Svenska Traumaregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "http://www.swetrau.se/",
+        "search_tags": [
+            "SweTrau",
+            "Traumaregistret",
+            "trauma",
+            "injury"
+        ],
+        "Information": "SweTrau collects data on trauma patients, including types of injuries, severity, treatments provided, and outcomes such as survival rates and functional recovery. The registry includes data from all major trauma centres and emergency departments in Sweden, ensuring comprehensive national coverage of trauma care and outcomes.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "AmbuReg – Ambulansregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/ambureg/",
+        "search_tags": [
+            "paramedic",
+            "AmbuReg",
+            "ambulance",
+            "emergency"
+        ],
+        "Information": "AmbuReg collects data on pre-hospital care provided by ambulance services in Sweden. This includes information on patient demographics, medical conditions, types of interventions performed, response times, and outcomes of pre-hospital treatment.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2016"
+    },
+    {
+        "name": "Analfistelregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "Analfistelregistret",
+            "colorectal",
+            "anal",
+            "fistula"
+        ],
+        "Information": "This registry collects information on patients undergoing treatment for anal fistulas, including demographic data, types of fistulas, surgical and non-surgical treatments, complications, and outcomes such as healing rates and recurrence.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "GamReg Sweden – Kvalitetsregister för spel- och dataspelsberoende",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register/gamreg-sweden",
+        "search_tags": [
+            "gamreg",
+            "addiction",
+            "gambling addiction",
+            "gaming addiction"
+        ],
+        "Information": "GamReg collects data on individuals seeking treatment for gambling and gaming addiction. This includes information on demographics, types of addiction, treatments provided (such as counselling or medication), and outcomes related to addiction severity and recovery. The registry covers multiple treatment centres and clinics across Sweden that specialise in addiction therapy.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2019"
+    },
+    {
+        "name": "Glaukomregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "optic nerve",
+            "glaucoma",
+            "vision",
+            "Glaukomregistret"
+        ],
+        "Information": "The Glaucoma Register collects data on patients diagnosed with glaucoma, including patient demographics, diagnostic criteria, intraocular pressure measurements, visual field data, treatments (medications or surgeries), and outcomes.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "LHON-registret – Registret för Lebers Hereditära Opticusneuropati",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://lhon-registret.se/om-lhon/",
+        "search_tags": [
+            "optic",
+            "Lebers",
+            "Leber's hereditary optic neuropathy",
+            "LHON-registret"
+        ],
+        "Information": "Data from the registry may be used to try to identify the risk of developing vision impairment. Since the registry not only includes individuals with vision impairment but also carriers of the genetic variants who have normal vision, the registry may eventually be used to identify environmental or lifestyle factors that preceded vision impairment.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2018"
+    },
+    {
+        "name": "LSR – Lund Stroke Register",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://portal.research.lu.se/sv/projects/lund-stroke-register",
+        "search_tags": [
+            "endovascular",
+            "Register",
+            "stroke",
+            "LSR"
+        ],
+        "Information": "The Lund Stroke Register collects data on patients admitted to the Lund University Hospital with a diagnosis of stroke. Data includes patient demographics, stroke type and severity, treatments provided, rehabilitation, and outcomes. The registry specifically covers patients treated at Lund University Hospital, providing detailed insights into stroke care and outcomes within this institution.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2001"
+    },
+    {
+        "name": "Njurtransplantationsregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "Njurtransplantationsregistret",
+            "renal",
+            "transplant",
+            "kidney"
+        ],
+        "Information": "Collects data on kidney transplant procedures and outcomes.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "Barnkirurgi operationsregister",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "paediatric surgeries",
+            "Barnkirurgi"
+        ],
+        "Information": "Monitors outcomes of paediatric surgeries.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "Register för brachyterapi vid uvealt melanom",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "melanoma",
+            "brachytherapy",
+            "Register",
+            "uveal melanoma"
+        ],
+        "Information": "Tracks outcomes of brachytherapy for uveal melanoma.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "Sklerodermiregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "skin",
+            "autoimmune",
+            "Sklerodermiregistret",
+            "scleroderma"
+        ],
+        "Information": "Monitors treatment outcomes for scleroderma patients.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "Svenska Lambåregistret",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "Svenska",
+            "Lambåregistret"
+        ],
+        "Information": "Tracks outcomes of flap surgeries and patient recovery.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "SweAAA – Svenskt Register för Abdominellt Aortaaneurysm",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "aortic",
+            "abdominal aortic aneurysm",
+            "vascular"
+        ],
+        "Information": "Monitors outcomes of abdominal aortic aneurysm treatments.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Sällsynta diagnoser",
+        "registry_centre": [
+            "Registercentrum Syd"
+        ],
+        "url": "https://rcsyd.se/anslutna-register",
+        "search_tags": [
+            "rare disease",
+            "genetic"
+        ],
+        "Information": "Collects data on rare diseases, focusing on diagnosis and treatment outcomes.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "PsoReg – Nationellt register för systembehandling av psoriasis",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://psoreg.se/",
+        "search_tags": [
+            "skin",
+            "psoriasis",
+            "PsoReg",
+            "psoriasis treatment"
+        ],
+        "Information": "soReg tracks patients undergoing systemic treatment for psoriasis, collecting data on treatment efficacy, patient demographics, disease severity, and quality of life. It covers dermatology clinics across Sweden, aiming for nationwide coverage to monitor long-term outcomes and improve patient care.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2006"
+    },
+    {
+        "name": "Riksstroke – Nationellt kvalitetsregister för strokesjukvård",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://www.riksstroke.org/sve/",
+        "search_tags": [
+            "Riksstroke",
+            "endovascular",
+            "stroke",
+            "kvalitetsregister"
+        ],
+        "Information": "Riksstroke gathers data on stroke care, including patient characteristics, acute treatment, rehabilitation, and long-term follow-up. It covers all hospitals in Sweden, ensuring comprehensive national coverage, and provides insights into stroke outcomes and healthcare quality improvements.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1994"
+    },
+    {
+        "name": "Svenskt Bråckregister  – Nationellt kvalitetsregister inom bråckkirurgi",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "http://svensktbrackregister.se/",
+        "search_tags": [
+            "bråck"
+        ],
+        "Information": "This register collects information on hernia surgeries, including patient demographics, surgical techniques, complications, and outcomes such as recurrence rates. It covers hospitals and clinics performing hernia surgeries in Sweden, providing comprehensive national data on treatment quality.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1992"
+    },
+    {
+        "name": "GynOp – Nationella kvalitetsregister inom gynekologisk kirurgi",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://www.gynop.se/",
+        "search_tags": [
+            "gynecological surgeries",
+            "GynOp",
+            "gynecological"
+        ],
+        "Information": "Tracks outcomes of gynaecological surgeries, collecting data on patient demographics, surgical methods, complications, and recovery. It covers nearly all hospitals in Sweden performing gynaecological surgeries, offering extensive national coverage to improve surgical outcomes and patient safety.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "SveATTR – Svenska transtyretinamyloidosregistret",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://regionvasterbotten.se/for-vardgivare/kunskapsstod/kvalitetsregistret-sveattr",
+        "search_tags": [
+            "transtyretinamyloidosregistret",
+            "SveATTR"
+        ],
+        "Information": "SveATTR collects data on patients with transthyretin amyloidosis and genetic carriers. It tracks patient demographics, treatments, and outcomes to improve care and facilitate research. It includes data from hospitals across Sweden,",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2019"
+    },
+    {
+        "name": "DBS – Kvalitetsregister inom deep brain stimulation",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://deepbrainstimulation.se/",
+        "search_tags": [
+            "DBS",
+            "stimulation",
+            "deep brain"
+        ],
+        "Information": "The registry tracks patients undergoing deep brain stimulation (DBS) for movement disorders. It collects data on surgical procedures, outcomes, and complications. Coverage includes hospitals performing DBS in Sweden​,",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "CKG – Kardiovaskulär genetik",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://www.regionvasterbotten.se/forskning/profilomraden/kardiovaskular-genetik",
+        "search_tags": [
+            "Kardiovaskulär",
+            "genetik",
+            "CKG",
+            "Cardiovascular"
+        ],
+        "Information": "This registry collects data on patients with genetic cardiovascular conditions, focusing on genetic information, treatments, and patient outcomes. It aims for national coverage​.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "Unknown"
+    },
+    {
+        "name": "Terapeutisk aferes – Internationellt register för terapeutisk aferes behandling",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://www.waa-registry.org/",
+        "search_tags": [
+            "aferes"
+        ],
+        "Information": "his international registry gathers data on therapeutic apheresis treatments, tracking patient demographics, procedures, and outcomes to improve treatment protocols across participating countries​.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "1992"
+    },
+    {
+        "name": "AURICULA – Nationellt register för förmaksflimmer och antikoagulation",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/auricula/",
+        "search_tags": [
+            "atrial fibrillation",
+            "aFib"
+        ],
+        "Information": "This registry collects data on patients with atrial fibrillation, focusing on diagnostic procedures, treatments, and outcomes to improve care for those requiring anticoagulation. It covers hospitals and clinics across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "GallRiks – Svenskt kvalitetsregister för gallstenskirurgi",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/gallriks/",
+        "search_tags": [
+            "GallRiks",
+            "cholecystectomy",
+            "gallstone surgery"
+        ],
+        "Information": "GallRiks monitors gallstone surgeries in Sweden, collecting data on over 12,000 gallbladder surgeries and 6,000 endoscopic procedures annually. It tracks complications, surgery types, and patient outcomes, aiming to reduce post-operative complications, which occur in 5-10% of cases. GallRiks covers all hospitals performing gallstone surgery, ensuring comprehensive national data​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2005"
+    },
+    {
+        "name": "Kateterablationsregistret – Nationellt kvalitetsregister för kateterablation vid hjärtrusningar",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "http://www.ablationsregistret.se/",
+        "search_tags": [
+            "kateterablation",
+            "cardiovascular"
+        ],
+        "Information": "This registry collects data on catheter ablation for arrhythmias, including procedural details and patient outcomes. It covers Swedish hospitals performing these procedures​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2004"
+    },
+    {
+        "name": "NRS – Nationellt register över smärtrehabilitering",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/nrs/",
+        "search_tags": [
+            "pain",
+            "pain rehab"
+        ],
+        "Information": "NRS gathers data on patients undergoing pain rehabilitation for chronic pain. It collects information on treatments, rehabilitation plans, and patient-reported outcomes to monitor and improve the quality of life for these patients. NRS covers clinics across Sweden and is aimed at both short- and long-term outcome analysis​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "RiksSvikt – Nationellt kvalitetsregister för hjärtsvikt",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/rikssvikt/",
+        "search_tags": [
+            "RiksSvikt",
+            "hear disease"
+        ],
+        "Information": "RiksSvikt collects data on patients with heart failure, focusing on diagnostics, treatments, and long-term outcomes. It aims to ensure that 90% of patients are treated according to national guidelines, covering most hospitals across Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2003"
+    },
+    {
+        "name": "RiksSår – Nationellt kvalitetsregister för svårläkta sår",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.rikssar.se/",
+        "search_tags": [
+            "svårläkta",
+            "RiksSår",
+            "wound"
+        ],
+        "Information": "This registry gathers data on patients with chronic wounds, focusing on wound types, treatments, and healing outcomes. It aims to improve care for patients with non-healing wounds and involves both primary and specialist care facilities across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "Senior alert – Nationellt kvalitetsregister för vård och omsorg",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.senioralert.se/",
+        "search_tags": [
+            "Senior",
+            "senior alert",
+            "treatment"
+        ],
+        "Information": "Senior alert monitors the care of over 500,000 elderly patients annually. It tracks risks like falls, malnutrition, and pressure ulcers, with national coverage in elderly care facilities, hospitals, and home care​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "SOReg – Scandinavian Obesity Surgery Registry",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/soreg/",
+        "search_tags": [
+            "Obesity",
+            "Scandinavian",
+            "Surgery",
+            "SOReg"
+        ],
+        "Information": "SOReg collects data from approximately 7,000 patients annually undergoing bariatric surgery in Sweden. It monitors surgical types, complications, and long-term outcomes, covering all bariatric surgery centres in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "SPAHR – Svenska PAH & CTEPH registret",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/spahr/",
+        "search_tags": [
+            "registret",
+            "CTEPH",
+            "SPAHR"
+        ],
+        "Information": "Includes about 500 patients diagnosed with pulmonary arterial hypertension (PAH) and chronic thromboembolic pulmonary hypertension (CTEPH) in Sweden. It focuses on tracking diagnosis, treatments, and outcomes​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "SPOR – Svenskt perioperativt register",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/spor/",
+        "search_tags": [
+            "register",
+            "SPOR",
+            "UCR",
+            "perioperativt"
+        ],
+        "Information": "SPOR collects perioperative data from over 1.2 million surgeries annually in Sweden, focusing on anaesthesia and post-surgical recovery. The registry helps improve patient safety in surgical care across Swedish hospitals​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "SveDem – Svenska registret för kognitiva sjukdomar/demenssjukdomar",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/svedem/",
+        "search_tags": [
+            "Cognitive",
+            "Dementia",
+            "UCR",
+            "SveDem"
+        ],
+        "Information": "SveDem tracks more than 90,000 patients with dementia, collecting data on cognitive evaluations, treatments, and long-term care plans. It includes primary care and memory clinics across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "SWEDCON – Barnhjärtregistret (inkluderar GUCH, det vill säga vuxna med medfött hjärtfel)",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/swedcon/",
+        "search_tags": [
+            "GUCH",
+            "children",
+            "heart",
+            "SWEDCON"
+        ],
+        "Information": "SWEDCON focuses on congenital heart disease, tracking surgeries, treatments, and outcomes for children and adults with congenital heart defects. It includes all centres in Sweden treating congenital heart disease, ensuring comprehensive national coverage​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1998"
+    },
+    {
+        "name": "SWEDEHEART – Sammanslagning av RIKS-HIA, SEPHIA, SCAAR, TAVI, Svenska Hjärtkirurgiregistret och Kardiogenetikregistret.",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/swedeheart/",
+        "search_tags": [
+            "SEPHIA",
+            "SCAAR",
+            "TAVI",
+            "SwEDEHEART"
+        ],
+        "Information": "SWEDEHEART is a national registry that includes data from acute coronary care (RIKS-HIA), coronary angiography (SCAAR), heart surgery, and secondary prevention (SEPHIA). It covers nearly all cardiac care units in Sweden, providing comprehensive data on heart disease management",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "SWEDEVOX – Andningssviktregistret över oxygenbehandling och respiratorbehandling i hemmet",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/swedevox/",
+        "search_tags": [
+            "oxygen",
+            "UCR",
+            "SWEDEVOX"
+        ],
+        "Information": "This registry collects data on patients receiving oxygen or ventilator therapy for respiratory failure at home. It tracks treatment outcomes and covers hospitals providing these services across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "SWEDVASC – Nationellt register för kärlkirurgi",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/swedvasc/",
+        "search_tags": [
+            "vain",
+            "SWEDVASC"
+        ],
+        "Information": "SWEDVASC includes more than 100,000 vascular surgery cases. It tracks procedures like aneurysm repairs and peripheral artery disease treatment from hospitals across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1994"
+    },
+    {
+        "name": "SVAR – Svenskt akutvårdsregister",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/svar/",
+        "search_tags": [
+            "acute",
+            "SVAR",
+            "acute care"
+        ],
+        "Information": "SVAR is a national registry designed to cover the entire emergency care process, including prehospital care, emergency departments, and acute wards. It currently tracks over 600,000 patient visits annually and aims to improve the quality of emergency care across Sweden. Data is automatically collected from patient records to ensure high coverage and reliability​.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "TBI – Traumatic Brain Injury",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/tbi/",
+        "search_tags": [
+            "TBI",
+            "Brain",
+            "Injury",
+            "Traumatic"
+        ],
+        "Information": "The Traumatic Brain Injury registry collects data on patients with severe brain injuries, focusing on trauma mechanisms, treatments, and rehabilitation outcomes. While no specific patient numbers were found, this registry is part of broader national efforts to improve care for trauma patients across Sweden​.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "ThoR – Allmän Thoraxkirurgi",
+        "registry_centre": [
+            "Uppsala Clinical Research Center"
+        ],
+        "url": "https://www.ucr.uu.se/thor/",
+        "search_tags": [
+            "ThoR",
+            "Thorax",
+            "Thoraxkirurgi"
+        ],
+        "Information": "collects data on surgeries involving the lungs, trachea, esophagus, pleura, pericardium, thymus, diaphragm, and the chest wall including bones and muscles. While a significant portion of the surgeries focus on lung cancer, it also includes data on surgeries for benign conditions. The registry tracks surgical outcomes and complications to improve thoracic surgery care across Sweden​.",
+        "category": [
+            "Other quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "BRIMP – Bröstimplantatregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://brimp.registercentrum.se/",
+        "search_tags": [
+            "Breast implant",
+            "Bröstimplantatregistret",
+            "BRIMP"
+        ],
+        "Information": "BRIMP collects data on all breast implant procedures, including both cosmetic and reconstructive surgeries. It tracks implant types, surgical methods, and complications, aiming to improve patient safety. The registry covers all healthcare providers that perform breast implant surgeries in Sweden, with about 9,936 breast implants tracked in the Västra Götaland region between 2014 and 2021.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2014"
+    },
+    {
+        "name": "Kranio – Kranioregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://kranio.registercentrum.se/",
+        "search_tags": [
+            "Kranioregistret",
+            "Kranio",
+            "cranial"
+        ],
+        "Information": "This registry collects data on patients undergoing cranial surgery for congenital malformations, trauma, or other conditions. It tracks surgical outcomes, complications, and long-term recovery but does not have widely available patient numbers. Coverage includes hospitals performing cranial surgeries across Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2023"
+    },
+    {
+        "name": "LVR – Luftvägsregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://lvr.registercentrum.se/",
+        "search_tags": [
+            "Luftvägsregistret",
+            "LVR",
+            "airways"
+        ],
+        "Information": "LVR gathers data on respiratory disorders, particularly focusing on patients requiring long-term oxygen or ventilator support. The registry tracks treatment types, patient demographics, and outcomes across Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "Nationellt kvalitetsregister för öron-, näs- och halssjukvård:",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://orl.registercentrum.se/",
+        "search_tags": [
+            "ear,",
+            "nose",
+            "throat",
+            "treatment"
+        ],
+        "Information": "Tracks treatments and outcomes for various ENT conditions. It includes nine sub-registries: surgery for hearing improvement with stapes prostheses, nasal septum surgery, tympanostomy tube surgeries, vocal cord surgery, hearing rehabilitation with hearing aids, cochlear implants, tonsillectomy, eardrum repair surgeries, and snoring surgeries. These registries cover hospitals and clinics across Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1997"
+    },
+    {
+        "name": "NDR – Nationella Diabetesregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://ndr.registercentrum.se/",
+        "search_tags": [
+            "NDR",
+            "Nationella",
+            "Diabetes"
+        ],
+        "Information":"The data collected focuses on glycaemic control, risk factors, complications, and treatment outcomes for patients with both type 1 and type 2 diabetes. It promotes evidence-based healthcare by making data available to healthcare providers for regular comparison and quality improvement efforts. The NDR is one of the largest diabetes registries in the world, covering nearly 90% of patients with diabetes in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1996"
+    },
+    {
+        "name": "NROK – Nationella registret för ortognatkirurgi",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://nrok.registercentrum.se/",
+        "search_tags": [
+            "orthognathic surgery",
+            "NROK"
+        ],
+        "Information": "This registry collects data on 900-1000 corrective jaw surgeries annually in Sweden. The focus is on improving care quality and ensuring equal access to treatment for patients with dentofacial anomalies. It tracks surgical outcomes and patient safety, helping to ensure consistent standards of care across clinics​",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2018"
+    },
+    {
+        "name": "QregPV – Primärvårdens kvalitetsregister Västra Götaland",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://qregpv.registercentrum.se/",
+        "search_tags": [
+            "QregPV"
+        ],
+        "Information": "This registry focuses on primary care for conditions like hypertension and coronary artery disease. It includes data from over 200,000 patients, helping healthcare providers track and improve treatment outcomes​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2006"
+    },
+    {
+        "name": "Riksfot – Svenska fotkirurgiska registret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://fot.registercentrum.se/",
+        "search_tags": [
+            "foot",
+            "feet",
+            "Riksfot",
+            "surgery"
+        ],
+        "Information": "The Swedish Fracture Register (SFR) tracks over 900,000 fractures and registers over 100,000 new fractures each year. It collects data on all types of fractures, both surgical and non-surgical, to improve treatment outcomes and reduce complications. The registry is used in research and clinical improvement efforts across Sweden​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "SESAR – Svenska Sömnapnéregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://sesar.registercentrum.se/",
+        "search_tags": [
+            "apnea",
+            "SESAR",
+            "sleep apnea"
+        ],
+        "Information": " focuses on tracking the diagnosis, treatment, and follow-up of patients with suspected or confirmed sleep apnea (mostly obstructive sleep apnea, OSA). The registry now includes around 120,000 patients. The number of healthcare units reporting to SESAR has grown steadily, and as of 2023, over 50 units are actively contributing data. In the last year, approximately 40,000 patient care events were registered, showing significant growth in both reporting and registry coverage​",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "SFR – Svenska Frakturregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://sfr.registercentrum.se/",
+        "search_tags": [
+            "SFR",
+            "fracture"
+        ],
+        "Information": "It aims to track all types of fractures treated in Sweden, with data covering fracture characteristics, patient demographics, injury types, and treatment outcomes. Both surgical and non-surgical treatments are recorded, including any subsequent reoperations or complications. The registry serves a dual purpose: improving clinical care through feedback on treatment outcomes and facilitating research. By 2023, more than 900,000 fractures had been registered, and over 100,000 new fractures are added each year​. The SFR is notable for being implemented across all 54 orthopaedic departments in Sweden, with most achieving a completeness of 75-95% in matching fractures to official health databases​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "SLR – Svenska Ledprotesregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://slr.registercentrum.se/",
+        "search_tags": [
+            "Ledprotesregistret",
+            "prothese",
+            "SLR"
+        ],
+        "Information": "s a national quality registry that tracks all hip and knee joint replacement surgeries, including primary operations, revisions, and osteotomies (surgical bone cuts to correct alignment) performed across Sweden. The registry was officially established in 2020 after merging two previously separate registers—the Swedish Hip Arthroplasty Register (started in 1979) and the Swedish Knee Arthroplasty Register (started in 1975). Since then, SLR has been systematically collecting data to monitor and improve the quality of joint replacement surgeries nationwide​. The registry covers all units performing joint replacements in Sweden, ensuring a very high coverage rate.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2020"
+    },
+    {
+        "name": "SPOQ – Svenskt Pediatriskt Ortopediskt Qvalitetsregister",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://spoq.registercentrum.se/",
+        "search_tags": [
+            "Ortopediskt",
+            "orthopedic",
+            "child",
+            "Pediatric care"
+        ],
+        "Information": "was established in 2015 and focuses on five major pediatric orthopedic conditions: hip instability (DDH), Perthes disease, slipped capital femoral epiphysis (SCFE), clubfoot (PEVA), and patellar dislocation. These conditions are significant for child orthopedics in Sweden, as untreated or delayed interventions can lead to lifelong physical impairments. The primary goal of SPOQ is to monitor and improve the quality of care by ensuring timely diagnosis and treatment. It tracks patient outcomes to prevent long-term issues like residual deformities, early-onset osteoarthritis, and the need for reoperations later in life. Data from the registry is used to evaluate treatment methods and inform clinical practice, with approximately 1 in 800 children born in Sweden being diagnosed with clubfoot​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2015"
+    },
+    {
+        "name": "Svenska Artrosregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://artrosregistret.registercentrum.se/",
+        "search_tags": [
+            "svenska artros",
+            "arthritis"
+        ],
+        "Information": "It tracks data on osteoarthritis (OA) care across Sweden, focusing on non-surgical, first-line treatments like education, physical activity, and weight control. The register aims to monitor the effects of these interventions on patients' pain levels, physical activity, and overall health. As of 2023, over 225,000 patients have been registered, with data collected via questionnaires before treatment, three months after, and one year post-treatment.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "Svenska Hjärt- lungräddningsregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://shlr.registercentrum.se/",
+        "search_tags": [
+            "cardiopulmonary resuscitation"
+        ],
+        "Information": "Plays a key role in tracking and improving cardiopulmonary resuscitation (CPR) efforts in Sweden. This registry is a vital tool in improving the chain of survival for heart attack victims, tracking critical factors such as time to intervention, quality of care, and long-term patient outcomes. Approximately 2,500 in-hospital cardiac arrests are reported annually, and out-of-hospital cases are similarly recorded, aiming for full coverage.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1990"
+    },
+    {
+        "name": "Svenska Thoraxtransplantationsregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://strax.registercentrum.se/",
+        "search_tags": [
+            "Thoraxtransplantationsregistret",
+            "transplant"
+        ],
+        "Information": "The registry focuses on monitoring heart and lung transplantations performed at the only two hospitals in Sweden where these surgeries are conducted: Skånes University Hospital in Lund and Sahlgrenska University Hospital in Gothenburg. STRAX aims to systematically collect information about patients before, during, and after their transplantation. This includes data from the waiting list, details of the surgeries, and lifelong follow-ups to track the success of the transplants and manage complications. Approximately 60-70 heart and lung transplants are performed annually in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2018"
+    },
+    {
+        "name": "Svenskt Register för Rehabiliteringsmedicin",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://svereh.registercentrum.se/",
+        "search_tags": [
+            "rehab",
+            "rehabilitation",
+            "Rehabiliteringsmedicin",
+            "svereh"
+        ],
+        "Information": "Aimed at improving rehabilitation services for patients with brain injuries, spinal cord injuries, and other complex conditions. The registry collects data on demographics, rehabilitation outcomes, waiting times, and patient satisfaction. The registry supports continuous improvement in service quality and is widely used for research purposes.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2021"
+    },
+    {
+        "name": "SWEAPS – Svenska registret för avancerad barn- och ungdomskirurgi",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://sweaps.registercentrum.se/",
+        "search_tags": [
+            "surgery",
+            "SWEAPS"
+        ],
+        "Information": "Gathers comprehensive data on children requiring complex surgical interventions due to congenital malformations in the esophagus, intestines, and urinary system. It covers rare conditions like esophageal atresia and congenital diaphragmatic hernia. The goal is to enhance care quality, reduce risks, and improve long-term patient outcomes. Data collected includes patient demographics, surgical details, and long-term follow-ups from specialised centres.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2016"
+    },
+    {
+        "name": "Bipolär- och psykosregistret – Nationellt kvalitetsregister för bipolär sjukdom och schizofrenispektrumtillstånd",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://bipsy.registercentrum.se/",
+        "search_tags": [
+            "Schizophrenia",
+            "bipolar",
+            "psychosis"
+        ],
+        "Information": "Collects and analyses data on patients with bipolar disorder and schizophrenia spectrum conditions. Currently, the registry covers around 13,000 individuals with bipolar disorder from 166 healthcare units across Sweden. It tracks variables such as the number of mood episodes, medication types, treatment outcomes, and age of onset. The data is used to improve the quality of care, evaluate new treatments, and support research in psychiatric care.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2004"
+    },
+    {
+        "name": "Bättre Beroendevård",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://battreberoendevard.registercentrum.se/",
+        "search_tags": [
+            "Beroendevård",
+            "addiction"
+        ],
+        "Information": "focuses on patients receiving specialised care for substance use disorders, covering diagnoses such as alcohol, opioid, and multi-substance dependencies (ICD-10 codes F10-F19). Established to improve the quality and accessibility of addiction treatment, the registry tracks data on care plans, participation in medication-assisted programs (e.g., LARO for opioid addiction), and questions about the patient’s family situation, such as the presence of minors. The registry collaborates with healthcare units across Sweden, ensuring that treatment outcomes are monitored and used to refine addiction care strategies.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "Kvalitetsregister ECT",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://ect.registercentrum.se/",
+        "search_tags": [
+            "ECT",
+            "electroconvulsive therapy"
+        ],
+        "Information": "he registry includes data on electroconvulsive therapy (ECT) treatments, which are used primarily for severe psychiatric conditions like depression. It has a coverage rate of approximately 96% as of 2022, with all hospitals in Sweden that provide ECT contributing data. Since 2018, it has also tracked repetitive transcranial magnetic stimulation (rTMS) treatments, covering 11 regions and with a 90% data coverage rate.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2012"
+    },
+    {
+        "name": "Q-bup – Nationellt kvalitetsregister för barn- och ungdomspsykiatri",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://qbup.registercentrum.se/",
+        "search_tags": [
+            "peadiatric care",
+            "child psychiatry",
+            "psychiatry"
+        ],
+        "Information": "focused on psychiatric care for children and adolescents across Sweden. Its primary aim is to improve the quality and equality of mental health services by collecting comprehensive data from various regions. This data includes patient demographics, diagnoses, treatments, and outcomes, providing a national benchmark for psychiatric services. As of recent reports, it had a national coverage rate of around 22%, with higher regional coverage in areas like Kalmar, Stockholm, Gävleborg, and Jämtland/Härjedalen, reaching 76%.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2017"
+    },
+    {
+        "name": "Riksät – Nationellt kvalitetsregister för ätstörningsbehandling",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://riksat.registercentrum.se/",
+        "search_tags": [
+            "Riksät",
+            "psychiatry",
+            "eating disorder"
+        ],
+        "Information": "It initially focused on specialised eating disorder units but has since expanded to include all eating disorder care in Sweden. The registry collects detailed data on patients, such as treatment duration, outcomes, and patient satisfaction, aiming to improve care quality and follow-up of treatment effects. Currently, approximately 50 units participate across 21 regions.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1999"
+    },
+    {
+        "name": "RättspsyK – Nationellt rättspsykiatriskt kvalitetsregister",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://rattspsyk.registercentrum.se/",
+        "search_tags": [
+            "rättspsykiatriskt",
+            "RättspsyK",
+            "psychiatry"
+        ],
+        "Information": "t tracks patients receiving forensic psychiatric care in Sweden, which involves compulsory treatment following legal decisions. The registry collects comprehensive data on 25 different indicators, including treatment plans, risk assessments, recidivism in criminal activity, use of coercive measures, and patient health status. In 2023, the registry followed up on 2,070 patients, marking its highest recorded coverage since inception.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "SibeR – Svenska internetbehandlingsregistret",
+        "registry_centre": [
+            "Registercentrum Västra Götaland"
+        ],
+        "url": "https://siber.registercentrum.se/",
+        "search_tags": [
+            "–",
+            "internetbehandlingsregistret",
+            "SibeR"
+        ],
+        "Information": "Collects data on internet-based psychological treatments, including cognitive behavioural therapy (iCBT), targeting mental health conditions across psychiatry, primary care, and somatic care. By 2021, SibeR had seen increasing use, with a significant portion of the data—70%—being directly transferred from patient records, facilitating streamlined data collection. The registry covers a wide range of treatments, including recent expansions into areas such as ADHD in adults and gastrointestinal issues.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2015"
+    },
+    {
+        "name": "Barnnjurregistret (BNR)",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://barnnjurregistret.se/",
+        "search_tags": [
+            "Barnnjurregistret",
+            "BNR"
+        ],
+        "Information": "Collects data on children and adolescents with kidney diseases in Sweden. It aims to improve care quality and monitor long-term outcomes for these patients. The register includes data from all paediatric nephrology units across the country, covering several hundred individuals. Key variables include disease diagnosis, treatments, and progression.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1998"
+    },
+    {
+        "name": "Barnreumaregistret",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://barnreumaregistret.se/",
+        "search_tags": [
+            "Barnreumaregistret",
+            "reuma",
+            "rheumatic disease"
+        ],
+        "Information": "Collects data on children with paediatric rheumatic diseases in Sweden. Its main purpose is to monitor the progression of these diseases, treatments given, comorbidities, and the health and quality of life of patients. Data from patients are used to track short- and long-term effects of treatments, allowing healthcare providers to improve the quality of care. The register covers all relevant healthcare units in Sweden.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "Registret för medfödda metabola sjukdomar (RMMS)",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://rmms.se/",
+        "search_tags": [
+            "born",
+            "RMMS"
+        ],
+        "Information": "Tracks and monitors 46 rare metabolic disorders. The registry aims to improve the care of individuals with inherited metabolic diseases by gathering comprehensive data on patient demographics, diagnoses, treatments, and outcomes. The registry currently has a national coverage rate of 71% (as of 2024). RMMS is critical for standardising care across different regions in Sweden and supports ongoing research and quality improvement in healthcare for these rare conditions. Approximately 50 new cases are diagnosed annually​.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "Svenska Barnhälsovårdsregistret (BHVQ)",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://bhvq.se/",
+        "search_tags": [
+            "child",
+            "BHVQ",
+            "Barnhälsovårdsregistret"
+        ],
+        "Information": "It collects comprehensive data on various health indicators for children, such as growth metrics, maternal mental health screenings, and language development assessments, across all child healthcare centres in Sweden. The registry includes variables such as vaccination status, parental support programs, and exposure to secondhand smoke, which are tracked from the child's first to final visits. BHVQ facilitates nationwide monitoring of child health services, supporting research and quality improvement initiatives.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "PIDcare",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://pidcare.se/",
+        "search_tags": [
+            "PIDcare"
+        ],
+        "Information": "The PIDcare registry focuses on individuals with primary immunodeficiencies (PID) and was established to improve care by tracking patient data, treatment outcomes, and long-term health. It collects detailed information on diagnosis, genetic findings, treatments, and immunological parameters.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2012"
+    },
+    {
+        "name": "Svenskt Njurregister (SNR)",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "https://www.medscinet.net/snr/",
+        "search_tags": [
+            "SNR",
+            "Njurregister",
+            "kidney"
+        ],
+        "Information": "Was established to monitor and improve the quality of kidney care in Sweden, tracking various aspects of treatment for patients with chronic kidney disease, dialysis, and kidney transplants. The registry covers virtually all dialysis and transplant centres in Sweden, ensuring comprehensive national coverage. Data variables include patient demographics, treatment outcomes, transplantation statistics, and long-term survival rates. By 2023, SNR had registered over 18,300 kidney transplants, with around 6,400 patients living with a functioning transplant. Each year, the registry reports on approximately 523 transplantations and a large number of dialysis treatments.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1991"
+    },
+    {
+        "name": "Swespine",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "http://www.swespine.se/",
+        "search_tags": [
+            "Swespine",
+            "spine",
+            "spine disorders"
+        ],
+        "Information": "It monitors spine surgeries performed across Sweden's orthopedic and neurosurgery clinics. By 2023, the registry included around 192,800 registered operations, with approximately 10,000 new spine surgeries added each year. The registry covers about 95% of the relevant clinics in Sweden, with a completeness rate of 85%, meaning a high proportion of patients who undergo spine surgery are captured.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "1998"
+    },
+    {
+        "name": "Swibreg",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "https://www.swibreg.se/",
+        "search_tags": [
+            "Swibreg"
+        ],
+        "Information": "Swibreg, the Swedish Inflammatory Bowel Disease Registry, was established to monitor and improve the care of individuals with inflammatory bowel diseases (IBD) like Crohn’s disease and ulcerative colitis. It tracks treatment outcomes, disease activity, and patient-reported quality of life across local, regional, and national levels. Swibreg currently includes data from over 64,000 registered patients.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "Svenska Palliativregistret",
+        "registry_centre": [
+            "Registercentrum Sydost"
+        ],
+        "url": "https://palliativregistret.se/",
+        "search_tags": [
+            "Svenska",
+            "Palliativregistret",
+            "pallitative"
+        ],
+        "Information": "Designed to improve palliative care for patients at the end of life. The registry aims to cover all deaths in Sweden, regardless of diagnosis, age, or place of death. The registry includes data from approximately 90,000 deaths per year, contributing to continuous improvements in palliative care across various healthcare units. Variables collected include symptom management, patient and family support, and care preferences.",
+        "category": [
+            "National quality registry"
+        ],
+        "start_date": "2005"
+    },
+    {
+        "name": "Nationellt kvalitetsregister akut lymfatisk leukemi",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/akut-lymfatiskt-leukemi-all/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister akut lymfatisk leukemi"
+        ],
+        "Information": "Established to support the treatment and care of patients diagnosed with this aggressive form of blood cancer, the registry collects comprehensive data on demographics, diagnosis, treatment protocols, and patient outcomes. Data variables include genetic markers, chemotherapy protocols, and remission rates, helping healthcare providers make informed decisions for better outcomes.",
+        "category": [
+            "National cancer quality registry",
+            "leukemi",
+            "leukemia"
+        ],
+        "start_date": "1997"
+    },
+    {
+        "name": "Akut myeloisk leukemi (AML) inklusive akut oklassificerad leukemi (AUL)",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/kunskapsstyrning/kvalitetsregister/",
+        "search_tags": [
+            "Akut myeloisk leukemi (AML) inklusive akut oklassificerad leukemi (AUL)"
+        ],
+        "Information": "Focuses on collecting detailed data related to acute myeloid leukemia (AML) and acute undifferentiated leukemia (AUL) in Sweden. This national cancer quality registry collects information on patient demographics, genetic markers, treatment protocols, and outcomes, with the aim of improving the care and survival of patients with these aggressive hematologic malignancies. Includes data from diagnostic processes, chemotherapy, bone marrow transplants, and patient follow-up care. Coverage is comprehensive across Sweden, including nearly all diagnosed patients.",
+        "category": [
+            "National cancer quality registry",
+            "leukemia",
+            "AUL",
+            "AML"
+        ],
+        "start_date": "1997"
+    },
+    {
+        "name": "Nationellt Kvalitetsregister för Bröstcancer NKBC",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/brost/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt Kvalitetsregister för Bröstcancer NKBC"
+        ],
+        "Information": "It collects comprehensive data on breast cancer patients, covering diagnosis, treatments, and outcomes. The registry includes data on tumour characteristics, surgical interventions, radiotherapy, chemotherapy, and hormone therapies, as well as patient demographics. NKBC is crucial for improving the quality of breast cancer care across the country by enabling continuous monitoring and benchmarking of clinical practices. The registry includes nearly all diagnosed breast cancer cases in Sweden.",
+        "category": [
+            "National cancer quality registry",
+            "breast cancer",
+            "bröstcancer"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Svenska kvalitetsregistret för gynekologisk cancer",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/gynekologi/kvalitetsregister/",
+        "search_tags": [
+            "Svenska kvalitetsregistret för gynekologisk cancer"
+        ],
+        "Information": "A registry for gynaecological cancers, covering cancers of the ovaries, uterus, cervix, and vulva. collects detailed information on patient demographics, tumour characteristics, treatments (surgical, radiological, and chemotherapeutic), and follow-up outcomes. Its aim is to enhance the quality of care provided to women diagnosed with gynaecological cancers through systematic data collection and analysis. By monitoring treatment efficacy and patient outcomes across the country, the registry facilitates improvements in clinical practices and supports research efforts. It includes nearly all gynaecological cancer cases treated in Sweden.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Nationellt kvalitetsregister hudmelanom (SweMR)",
+        "registry_centre": [
+            "RCC Syd"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hud-och-melanom/malignt-melanom/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister hudmelanom (SweMR)"
+        ],
+        "Information": "Focuses on tracking and improving the care and outcomes of patients diagnosed with skin melanoma. The registry collects extensive data on tumour characteristics, treatment approaches (such as surgery and immunotherapy), and patient follow-up information. Key variables include Breslow thickness, ulceration, and metastasis status, all of which are critical for prognosis. The registry covers nearly all melanoma cases diagnosed in Sweden",
+        "category": [
+            "National cancer quality registry",
+            "melanoma",
+            "skin cancer"
+        ],
+        "start_date": "2003"
+    },
+    {
+        "name": "Svenskt kvalitetsregister för huvud- och halscancer",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/huvud-och-hals/kvalitetsregister/",
+        "search_tags": [
+            "Svenskt kvalitetsregister för huvud- och halscancer",
+            "throat cancer",
+            "cancer"
+        ],
+        "Information": "The registry focuses on collecting data from patients diagnosed with cancers of the oral cavity, pharynx, larynx, salivary glands, and other related areas. It gathers comprehensive data on tumour characteristics, treatment methods (such as surgery, radiotherapy, and chemotherapy), and patient outcomes. The registry is instrumental in improving the quality of care by enabling continuous monitoring of treatment effectiveness and survival rates. Covers nearly all cases of head and neck cancer in Sweden.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Svenska Hypofysregistret",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hypofys/kvalitetsregister-for-hypofystumorer/",
+        "search_tags": [
+            "Svenska Hypofysregistret",
+            "pituitary gland",
+            "cancer"
+        ],
+        "Information": "The Svenska Hypofysregistret is Sweden's national quality registry for pituitary tumours and other related conditions affecting the pituitary gland. The registry collects data on patient demographics, tumour types, treatment protocols (such as surgery, radiotherapy, and medical treatments), and long-term outcomes. It includes detailed information about hormonal imbalances caused by pituitary disorders and tracks the effects of different treatment approaches on patient recovery and quality of life. The registry covers cases from various healthcare providers across Sweden, ensuring that nearly all pituitary tumour patients are included.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2011"
+    },
+    {
+        "name": "Nationellt kvalitetsregister kronisk lymfatisk leukemi",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister kronisk lymfatisk leukemi"
+        ],
+        "Information": "The registry aims to collect comprehensive data on patients diagnosed with CLL, including demographic information, genetic markers, treatment approaches, and patient outcomes. Key variables tracked include treatment response, disease progression, and long-term survival rates. The registry provides insights into how different therapeutic strategies affect patient outcomes and supports ongoing clinical research.",
+        "category": [
+            "National cancer quality registry",
+            "CLL",
+            "leukemia"
+        ],
+        "start_date": "2007"
+    },
+    {
+        "name": "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lever-och-galla/kvalitetsregister/",
+        "search_tags": [
+            "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
+            "liver",
+            "gallbladder",
+            "cancer"
+        ],
+        "Information": "Sweden’s national quality registry for cancers of the liver, gallbladder, and bile ducts. The registry collects data on patient demographics, tumour characteristics, treatments such as surgery, chemotherapy, and radiotherapy, and long-term outcomes, including survival rates. SweLiv covers nearly all cases of liver, gallbladder, and biliary cancers treated in Sweden, providing a comprehensive dataset that helps guide clinical practice and supports research efforts to improve treatment strategies​.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "Nationellt kvalitetsregister lymfom",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/lymfom-lymfkortelcancer/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister lymfom"
+        ],
+        "Information": "Sweden’s national quality registry for lymphoma, covering various types of lymphatic cancers such as Hodgkin's lymphoma and non-Hodgkin's lymphoma. Collects detailed data on patient demographics, tumour characteristics, treatment methods (including chemotherapy, immunotherapy, and radiation), and long-term outcomes. It provides comprehensive national coverage, capturing nearly all lymphoma cases treated in Sweden. ",
+        "category": [
+            "National cancer quality registry",
+            "Hodking's lymphoma",
+            "lymphoma"
+        ],
+        "start_date": "2000"
+    },
+    {
+        "name": "Nationellt kvalitetsregister myelodysplastiskt syndrom",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelodysplastiskt-syndrom-mds/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister myelodysplastiskt syndrom",
+            "blood disorder",
+            "myelodysplastic"
+        ],
+        "Information": "A quality registry for myelodysplastic syndromes, a group of blood disorders that affect the bone marrow and lead to inefficient blood cell production. Collects data on patient demographics, genetic mutations, disease subtypes, treatment protocols (such as supportive care, chemotherapy, and stem cell transplantation), and long-term outcomes. The registry covers nearly all diagnosed cases of MDS in Sweden.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myeloproliferativa-sjukdomar-mpn/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
+            "MPN",
+            "myeloproliferative"
+        ],
+        "Information": "This MPN registry collects data on patient demographics, disease subtypes, genetic markers (such as JAK2 mutations), treatments (including cytoreductive therapy, interferon, and bone marrow transplants), and long-term outcomes like disease progression and survival rates. Covering nearly all diagnosed cases in Sweden, this registry provides valuable insights for standardising treatment protocols and enhancing patient care.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Nationellt kvalitetsregister myelom",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelom/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister myelom",
+            "myeloma"
+        ],
+        "Information": "Sweden’s national quality registry for multiple myeloma, a cancer of plasma cells. Collects comprehensive data on patients with myeloma, including patient demographics, genetic markers, disease stage, and treatment regimens such as chemotherapy, immunotherapy, and stem cell transplantation. ",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2008"
+    },
+    {
+        "name": "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/neuroendokrina-buktumorer/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
+            "GEP-NET"
+        ],
+        "Information": "The registry collects extensive data on patient demographics, tumour characteristics, genetic markers, treatments (such as surgery, targeted therapies, and peptide receptor radionuclide therapy), and patient outcomes like survival rates and tumour progression. GEP-NET provides nearly complete coverage of cases in Sweden.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2010"
+    },
+    {
+        "name": "Cancer utan känd primärtumör, CUP",
+        "registry_centre": [
+            "RCC Norr"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/okand-primartumor/",
+        "search_tags": [
+            "Cancer utan känd primärtumör, CUP",
+            "CUP",
+            "primary origin"
+        ],
+        "Information": "Sweden's national quality registry for cancer of unknown primary origin.  It collects detailed data on patient demographics, diagnostic procedures, treatment approaches (such as chemotherapy, radiotherapy, and palliative care), and patient outcomes.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2013"
+    },
+    {
+        "name": "Forskningsregister för skelettmetastaser",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/overgripande-kunskapsstod/skelettmetastaser/",
+        "search_tags": [
+            "Forskningsregister för skelettmetastaser",
+            "bone metastases",
+            "cancer"
+        ],
+        "Information": "Focuses on bone metastases and collects data on cancer type, treatment approaches (such as radiotherapy, surgery, or medication to strengthen bones), and patient outcomes like pain relief, mobility, and survival. The registry covers nearly all cases of skeletal metastases treated in Sweden, making it an essential tool for improving patient care and treatment strategies.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2009"
+    },
+    {
+        "name": "Nationellt kvalitetsregister sköldkörtelcancer",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/skoldkortel/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister sköldkörtelcancer",
+            "thyroid cancer",
+            "thyroid"
+        ],
+        "Information": "Sweden’s national quality registry for thyroid cancer, established to monitor and improve the care and outcomes for patients diagnosed with this type of cancer. The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, radioactive iodine therapy, and hormone replacement), and patient outcomes, including survival rates and recurrence.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2003"
+    },
+    {
+        "name": "SveReKKS - kvalitetsregister",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/Screening-tjock-och-andtarmscancer/sverekks/",
+        "search_tags": [
+            "SveReKKS - kvalitetsregister"
+        ],
+        "Information": "Focuses on colorectal cancer screening and prevention. Collects detailed data on screening participation rates, diagnostic results, follow-up procedures, and treatment outcomes. This registry supports Sweden’s organised colorectal cancer screening program, aimed at early detection and treatment of precancerous lesions and cancer in the colon and rectum. ",
+        "category": [
+            "National cancer quality registry",
+            "colorectal cancer"
+        ],
+        "start_date": "2017"
+    },
+    {
+        "name": "Nationellt kvalitetsregister för analcancer",
+        "registry_centre": [
+            "RCC Norr"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/tjocktarm-andtarm-och-anal/anal/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för analcancer"
+        ],
+        "Information": "Sweden’s national quality registry for anal cancer. It was established to improve the diagnosis, treatment, and outcomes of patients with this relatively rare form of cancer. The registry collects data on patient demographics, tumour characteristics, treatment methods (such as chemotherapy, radiotherapy, and surgery), and long-term patient outcomes, including survival rates and recurrence.",
+        "start_date": "2015",
+        "category": [
+            "National cancer quality registry",
+            "anal cancer"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för barncancer",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/barn/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för barncancer",
+            "peadiatric cancer",
+            "cancer"
+        ],
+        "Information": "Established to improve the care and outcomes for children diagnosed with cancer, it gathers detailed information on patient demographics, cancer types, treatment protocols (such as chemotherapy, radiotherapy, and surgery), and long-term outcomes. The registry covers nearly all cases of paediatric cancer across Sweden, tracking patient survival rates, treatment effectiveness, and any late effects of therapy.",
+        "start_date": "2011",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
+        "registry_centre": [
+            "RCC Syd"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/bukspottkortel/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
+            "pancreatic cancer"
+        ],
+        "Information": "The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, chemotherapy, and radiotherapy), and long-term outcomes, including survival rates. Covers nearly all pancreatic cancer cases in Sweden.​",
+        "start_date": "2011",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/gynekologisk-cellprovskontroll/kvalitetsregister/",
+        "search_tags": [
+            "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)"
+        ],
+        "Information": "Includes data on screening, diagnosis, and treatment for cervical cancer across Sweden. It collects information on screening participation, follow-up procedures, and patient outcomes to monitor and improve the effectiveness of the national cervical cancer screening program. The registry covers nearly all eligible women in Sweden who participate in routine screening.",
+        "start_date": "1999",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
+        "registry_centre": [
+            "RCC Norr"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hjarna-och-ryggmarg/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
+            "CNS",
+            "brain tumour"
+        ],
+        "Information": "Sweden's national quality registry for brain tumours and central nervous system (CNS) cancers. t collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment methods (such as surgery, radiotherapy, and chemotherapy), and long-term outcomes like survival rates and neurological function.",
+        "start_date": "2009",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för KML",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-myeloisk-leukemi-kml/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för KML",
+            "chronic lyeloid leukemia"
+        ],
+        "Information": "Collects detailed data on patients diagnosed with this specific type of leukemia, tracking treatment methods (such as tyrosine kinase inhibitors), disease progression, and long-term patient outcomes, including survival rates and quality of life. It covers most patients diagnosed with KML in the country. ",
+        "start_date": "2002",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för lungcancer",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lunga-och-lungsack/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för lungcancer",
+            "lung cancer"
+        ],
+        "Information": "It collects comprehensive data on patient demographics, tumour characteristics, diagnostic procedures, treatment approaches (such as surgery, radiotherapy, chemotherapy, and immunotherapy), and long-term outcomes, including survival rates. Covers almost all lung cancer cases in Sweden.",
+        "start_date": "2002",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
+        "registry_centre": [
+            "RCC Syd"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/matstrupe-och-magsack/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
+            "gastric cancers",
+            "cancer"
+        ],
+        "Information": "Sweden’s national quality registry for oesophageal and gastric cancers. It collects detailed data on patient demographics, tumour characteristics, diagnostic procedures, treatment modalities (including surgery, chemotherapy, and radiotherapy), and patient outcomes such as survival rates and post-treatment quality of life.",
+        "start_date": "2007",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för njurcancer",
+        "registry_centre": [
+            "RCC Norr"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/njure/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för njurcancer",
+            "kidney cancer"
+        ],
+        "Information": "The registry tracks patient demographics, tumour characteristics, treatment modalities (such as surgery, targeted therapies, and immunotherapies), and long-term outcomes, including survival rates and quality of life. By covering nearly all kidney cancer cases in Sweden, the registry plays a crucial role in improving treatment standards, facilitating clinical research, and informing national guidelines for managing kidney cancer​.",
+        "start_date": "2005",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/prostatacancertestning/kvalitetsregister/",
+        "search_tags": [
+            "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
+            "prostate cancer",
+            "prostate"
+        ],
+        "Information": "The registry gathers comprehensive data on screening participation, test results (such as PSA levels), diagnostic procedures, and follow-up treatments, ensuring consistency and quality in prostate cancer testing across Sweden.",
+        "start_date": "2023",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för sarkom",
+        "registry_centre": [
+            "RCC Syd"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/sarkom/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för sarkom",
+            "ewings sarcoma",
+            "sarcoma"
+        ],
+        "Information": "The registry aims to improve the diagnosis, treatment, and outcomes for patients with various forms of sarcoma, including osteosarcoma, Ewing’s sarcoma, and soft tissue sarcomas. It collects data on patient demographics, tumour characteristics, surgical interventions, chemotherapy, and radiotherapy treatments, as well as long-term outcomes such as recurrence rates and survival.",
+        "start_date": "2009",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för testikelcancer seminom",
+        "registry_centre": [
+            "RCC Syd"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/testikel/kvalitetsregister/#:~:text=Det%20nationella%20kvalitetsregistret%20för%20seminom,behandling%20av%20testikelcancer%20i%20Sverige.",
+        "search_tags": [
+            "Nationellt kvalitetsregister för testikelcancer seminom",
+            "prostate cancer"
+        ],
+        "Information": "The registry aims to improve the quality of care by allowing clinics and regions to compare their data with national statistics, providing insights into survival rates, tumour stages, and treatment effectiveness. It also facilitates research, including biobanking initiatives, by providing information on biological samples",
+        "start_date": "2000",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
+        "registry_centre": [
+            "RCC Sydöst"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/tjocktarm-andtarm-och-anal/tjock--och-andtarm/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
+            "colorectal cancer"
+        ],
+        "Information": "It collects comprehensive data on patients diagnosed with colorectal cancer, focusing on diagnosis, surgical treatments, radiotherapy, chemotherapy, and outcomes. The aim is to improve treatment protocols and outcomes by comparing data across hospitals and regions. The registry covers all major hospitals in Sweden and ensures complete national coverage. As of recent years, it tracks thousands of new cases annually, with around 6,000 new patients added each year.",
+        "start_date": "2007",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för urinblåsecancer",
+        "registry_centre": [
+            "RCC Stockholm Gotland"
+        ],
+        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/urinblasa-urinvagar/kvalitetsregister/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för urinblåsecancer",
+            "bladder cancer"
+        ],
+        "Information": "It collects detailed information on patients diagnosed with bladder cancer, including tumour stage, grade, treatment methods (such as surgery, radiotherapy, chemotherapy, or immunotherapy), and long-term outcomes. The primary aim is to improve clinical practice by tracking treatments and outcomes across all hospitals in Sweden, ensuring uniform quality standards. The registry also supports research by providing data for evaluating treatment effectiveness. Annually, around 2,000 new bladder cancer cases are registered.",
+        "start_date": "1997",
+        "category": [
+            "National cancer quality registry"
+        ]
+    }
+]

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -1,53 +1,68 @@
 export interface ILink {
-    text: string;
-    classes: string;
-    link: string;
-};
+  text: string;
+  classes: string;
+  link: string;
+}
 
 export interface ISVG {
-    href: string;
-    xmlns: string;
-    width: string;
-    height: string;
-    viewBox: string;
-    classes: string;
-    svg: string;
-};
+  href: string;
+  xmlns: string;
+  width: string;
+  height: string;
+  viewBox: string;
+  classes: string;
+  svg: string;
+}
 
 export interface ICardConfig {
-    cardClasses: string;
-    titleClasses: string;
-    subTitleClasses: string;
-    textClasses: string;
-    imgClasses: string;
-    buttonClasses: string;
-    buttonPlacement: string;
-};
+  cardClasses: string;
+  titleClasses: string;
+  subTitleClasses: string;
+  textClasses: string;
+  imgClasses: string;
+  buttonClasses: string;
+  buttonPlacement: string;
+}
 
 export interface ICardContent {
-    title: string; 
-    subTitle: string;
-    text: string; 
-    buttonText: string;
-    imageSrc: string;
-    imageAlt: string;
-};
+  title: string;
+  subTitle: string;
+  text: string;
+  buttonText: string;
+  imageSrc: string;
+  imageAlt: string;
+}
 
 export interface IDataSourceFilters {
-    dataTypes: string[];
-    diseaseTypes: string[];
-};
+  dataTypes: string[];
+  diseaseTypes: string[];
+}
 
 export interface IDataSourcesDC {
-    data: string[];
-    ddls: string[];
-    description: string;
-    name: string;
-    search_tags: string[];
-    target: string[];
-    thumbnail: string;
-    thumbnail_border?: boolean;
-    type: string[];
-    url: string;
-    disease_type: string[]
-};
+  data: string[];
+  ddls: string[];
+  description: string;
+  name: string;
+  search_tags: string[];
+  target: string[];
+  thumbnail: string;
+  thumbnail_border?: boolean;
+  type: string[];
+  url: string;
+  disease_type: string[];
+}
+
+export interface RegistrySources {
+  start_date: string;
+  category: string[];
+  name: string;
+  registry_centre: string[];
+  url: string;
+  search_tags: string[];
+  Information: string;
+}
+
+export interface RegistrySourcesFilters {
+  registryCentre: string[];
+  registryCategory: string[];
+}


### PR DESCRIPTION
This PR consists of two commits:
1. The arrow button svg on the clinical data access page has been removed.
2. The registry page was added to the Next JS setup. It was not part of it prior. Since the file was quite long, I tried separating it in two and using a server component to fetch the JSON. It is not necessary due to the JSON being rather small but I think it's best practice. It worked locally but I see no issues why it wouldn't work when deployed.