### PR TITLE
Arrow link to swedish research projects page

### DIFF
--- a/next-app/src/app/accessclinicaldata/page.tsx
+++ b/next-app/src/app/accessclinicaldata/page.tsx
@@ -42,8 +42,8 @@ export default function AboutPage(): ReactElement {
           human data is often not freely available. Researchers seeking access
           to human data must submit an application outlining their project and
           its requirements. The responsible institution, typically a healthcare
-          region or university, will release the data only after conducting
-          harm and confidentiality assessments.
+          region or university, will release the data only after conducting harm
+          and confidentiality assessments.
         </p>
         <p>
           If sensitive personal data (
@@ -68,34 +68,50 @@ export default function AboutPage(): ReactElement {
           data and the process of data disclosure vary between different
           authorities and organisations.
         </p>
-        <Title level={2}>Swedish research projects or databases</Title>
+        <div className="flex flex-row items-center">
+          <Title level={2}>Swedish research projects or databases</Title>
+          <Link href="/swedishresearchprojects">
+            <svg
+              className="ml-2 fill-primary w-7 h-7"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 32 32"
+            >
+              <g data-name="19-Arrow Right">
+                <path d="M16 0a16 16 0 1 0 16 16A16 16 0 0 0 16 0zm0 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14z" />
+                <path d="m26.71 15.29-7-7-1.42 1.42 5.3 5.29H5v2h18.59l-5.29 5.29 1.41 1.41 7-7a1 1 0 0 0 0-1.41z" />
+              </g>
+            </svg>
+          </Link>
+        </div>
         <p>
-  It is possible to request existing data from several research projects or
-  research databases in Sweden. Projects can be found, for example, on the
-  website of the project’s entity responsible for the research, the{" "}
-  <a
-    href="https://snd.se/en/catalogue/search"
-    target="_blank"
-    className="text-primary hover:text-black underline"
-  >
-    Swedish National Data Service (SND)
-  </a>
-  , or the{" "}
-  <a
-    href="https://precision-medicine-portal.scilifelab.se/swedishresearchprojects"
-    target="_blank"
-    className="text-primary hover:text-black underline"
-  >
-    Precision Medicine Portal
-  </a>
-  .
-</p>
-<p>
-  In the research data catalogue at SND, it is possible to search for research
-  projects and data from several disciplines. Some data and metadata can be
-  downloaded directly from the catalogue. SND also provides information about
-  data management and a service for data sharing.
-</p>
+          It is possible to request existing data from several research projects
+          or research databases in Sweden. Projects can be found, for example,
+          on the website of the project’s entity responsible for the research,
+          the{" "}
+          <a
+            href="https://snd.se/en/catalogue/search"
+            target="_blank"
+            className="text-primary hover:text-black underline"
+          >
+            Swedish National Data Service (SND)
+          </a>
+          , or the{" "}
+          <a
+            href="https://precision-medicine-portal.scilifelab.se/swedishresearchprojects"
+            target="_blank"
+            className="text-primary hover:text-black underline"
+          >
+            Precision Medicine Portal
+          </a>
+          .
+        </p>
+        <p>
+          In the research data catalogue at SND, it is possible to search for
+          research projects and data from several disciplines. Some data and
+          metadata can be downloaded directly from the catalogue. SND also
+          provides information about data management and a service for data
+          sharing.
+        </p>
         <div className="flex flex-row items-center">
           <Title level={2}>Quality registries</Title>
           <Link href="/registries">
@@ -204,99 +220,98 @@ export default function AboutPage(): ReactElement {
             </a>
           </li>
         </ul>
-        <p>
-        </p>
+        <p></p>
         <Title level={2}>Research data management</Title>
-<p>
-  SciLifeLab provides general research data management (RDM) guidelines,{" "}
-  <a
-    href="https://data-guidelines.scilifelab.se/"
-    target="_blank"
-    className="text-primary hover:text-black underline"
-  >
-    available here
-  </a>
-  , and specific information about the ethical, legal, and societal
-  implications (ELSI) for research involving human data,{" "}
-  <a
-    href="https://data-guidelines.scilifelab.se/topics/research-involving-human-data/"
-    target="_blank"
-    className="text-primary hover:text-black underline"
-  >
-    available here
-  </a>
-  . They also offer guidance on{" "}
-  <a
-    href="https://data-guidelines.scilifelab.se/topics/sharing-human-data/"
-    target="_blank"
-    className="text-primary hover:text-black underline"
-  >
-    sharing sensitive human data
-  </a>
-  .
-</p>
-<p>
-  More information and tailored research support can be found at universities,
-  colleges, and healthcare regions or hospitals. A selection of links:
-</p>
-<ul className="list-disc pl-4">
-  <li>
-    <a
-      href="https://www.oru.se/english/research/research-support/"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Örebro University
-    </a>
-  </li>
-  <li>
-    <a
-      href="https://www.oru.se/english/research/research-support/"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Karolinska University Hospital
-    </a>
-  </li>
-  <li>
-    <a
-      href="https://www.staff.lu.se/research-and-education/research-support"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Lund University
-    </a>
-  </li>
-  <li>
-    <a
-      href="https://www.umu.se/en/research-support-and-collaboration-office/"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Umeå University
-    </a>
-  </li>
-  <li>
-    <a
-      href="https://www.uu.se/en/staff/gateway/research/research-handbook/uppsala-universitys-research-support/the-medfarm-research-support"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Uppsala University
-    </a>
-  </li>
-  <li>
-    <a
-      href="https://staff.ki.se/research-support"
-      target="_blank"
-      className="text-primary hover:text-black underline"
-    >
-      Karolinska Universitetet
-    </a>
-  </li>
-</ul>
-<LastUpdated date="11-11-2024" />
-
+        <p>
+          SciLifeLab provides general research data management (RDM) guidelines,{" "}
+          <a
+            href="https://data-guidelines.scilifelab.se/"
+            target="_blank"
+            className="text-primary hover:text-black underline"
+          >
+            available here
+          </a>
+          , and specific information about the ethical, legal, and societal
+          implications (ELSI) for research involving human data,{" "}
+          <a
+            href="https://data-guidelines.scilifelab.se/topics/research-involving-human-data/"
+            target="_blank"
+            className="text-primary hover:text-black underline"
+          >
+            available here
+          </a>
+          . They also offer guidance on{" "}
+          <a
+            href="https://data-guidelines.scilifelab.se/topics/sharing-human-data/"
+            target="_blank"
+            className="text-primary hover:text-black underline"
+          >
+            sharing sensitive human data
+          </a>
+          .
+        </p>
+        <p>
+          More information and tailored research support can be found at
+          universities, colleges, and healthcare regions or hospitals. A
+          selection of links:
+        </p>
+        <ul className="list-disc pl-4">
+          <li>
+            <a
+              href="https://www.oru.se/english/research/research-support/"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Örebro University
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.oru.se/english/research/research-support/"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Karolinska University Hospital
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.staff.lu.se/research-and-education/research-support"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Lund University
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.umu.se/en/research-support-and-collaboration-office/"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Umeå University
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.uu.se/en/staff/gateway/research/research-handbook/uppsala-universitys-research-support/the-medfarm-research-support"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Uppsala University
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://staff.ki.se/research-support"
+              target="_blank"
+              className="text-primary hover:text-black underline"
+            >
+              Karolinska Universitetet
+            </a>
+          </li>
+        </ul>
+        <LastUpdated date="11-11-2024" />
       </div>
     </div>
   );


### PR DESCRIPTION
Added new arrow link on the access clinical data page that refers to the swedish research projects page.