### PR TITLE
other/431-check-packagelock-name-version

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "next-app",
-  "version": "0.1.0",
+  "name": "precision-medicine-portal-frontend",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-app",
-      "version": "0.1.0",
+      "name": "precision-medicine-portal-frontend",
+      "version": "0.10.0",
+      "license": "MIT",
       "dependencies": {
         "@jonkoops/matomo-tracker-react": "^0.7.0",
         "@radix-ui/react-checkbox": "^1.1.2",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precision-medicine-portal-frontend",
-  "version": "0.1.0",
+  "version": "0.10.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "next-app",
+  "name": "precision-medicine-portal-frontend",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-431

This pull request includes important updates to the project metadata in the `package.json` and `package-lock.json` files. The changes primarily involve renaming the project and updating its version and license information.

Project metadata updates:

* [`next-app/package-lock.json`](diffhunk://#diff-99a930acd0ca4a6e47f7bcec8ac1c893bdc7c0c9fe44012f9363ce1e0658f6c8L2-R10): Changed the project name from `next-app` to `precision-medicine-portal-frontend`, updated the version from `0.1.0` to `0.10.0`, and added the MIT license.
* [`next-app/package.json`](diffhunk://#diff-d4e3083fb353fab348c99d92bb87d7e0b98b99ef6d5a01c7278af1216b6f3997L2-R5): Changed the project name from `next-app` to `precision-medicine-portal-frontend`, updated the version from `0.1.0` to `0.10.0`, and added the MIT license.