### PR TITLE
other/485-update-codeowners-files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ScilifelabDataCentre/TeamPinga
+* @JanProgrammierung @SevLG


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-485

This pull request includes a small change to the `.github/CODEOWNERS` file. The change updates the ownership assignment to reflect the current team members.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Reassigned ownership from `@ScilifelabDataCentre/TeamPinga` to `@JanProgrammierung` and `@SevLG`.