### PR TITLE
fix/496-fix-terminal-errors

### DIFF
--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -113,18 +113,18 @@ export default function Footer(): ReactElement {
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
-                  shape-rendering="geometricPrecision"
-                  text-rendering="geometricPrecision"
-                  image-rendering="optimizeQuality"
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"
+                  shapeRendering="geometricPrecision"
+                  textRendering="geometricPrecision"
+                  imageRendering="optimizeQuality"
+                  fillRule="evenodd"
+                  clipRule="evenodd"
                   width="24"
                   height="24"
                   viewBox="0 0 511.999 452.266"
                   fill="currentColor"
                 >
                   <path
-                    fill-rule="nonzero"
+                    fillRule="nonzero"
                     d="M110.985 30.442c58.695 44.217 121.837 133.856 145.013 181.961 23.176-48.105 86.322-137.744 145.016-181.961 42.361-31.897 110.985-56.584 110.985 21.96 0 15.681-8.962 131.776-14.223 150.628-18.272 65.516-84.873 82.228-144.112 72.116 103.55 17.68 129.889 76.238 73 134.8-108.04 111.223-155.288-27.905-167.385-63.554-3.489-10.262-2.991-10.498-6.561 0-12.098 35.649-59.342 174.777-167.382 63.554-56.89-58.562-30.551-117.12 72.999-134.8-59.239 10.112-125.84-6.6-144.112-72.116C8.962 184.178 0 68.083 0 52.402c0-78.544 68.633-53.857 110.985-21.96z"
                   />
                 </svg>


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-496

This pull request updates the `FooterComponent` to use camelCase for SVG attribute names, aligning with React's JSX conventions.

### Code consistency updates:

* [`next-app/src/components/FooterComponent.tsx`](diffhunk://#diff-0bd92a635709c60f76cdebfa9b88d618b984f14bac48f0d9bfe87062951c061aL116-R127): Updated SVG attribute names from kebab-case (e.g., `fill-rule`, `clip-rule`) to camelCase (e.g., `fillRule`, `clipRule`) for compatibility with JSX syntax.