### PR TITLE
other/559-remove-backend-link-on-portal

### DIFF
--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -54,16 +54,17 @@ export default function Footer(): ReactElement {
     },
   };
 
-  // get frontend and backend image versions
+  // get frontend and backend image versions; uncomment backend when backend is ready
   const [frontendImage, setFrontendImage] = useState<string | null>(null);
-  const [backendImage, setBackendImage] = useState<string | null>(null);
+  // const [backendImage, setBackendImage] = useState<string | null>(null);
 
+  // uncomment backend when backend is ready
   useEffect(() => {
     fetch("/meta/version")
       .then((res) => res.json())
       .then((data) => {
         setFrontendImage(data.frontendImage);
-        setBackendImage(data.backendImage);
+        // setBackendImage(data.backendImage);
       });
   }, []);
 
@@ -239,7 +240,7 @@ export default function Footer(): ReactElement {
             >
               Github{" "}
             </a>
-            (Frontend version v
+            (Version v
             <a
               href={"https://" + frontendImage || "/"}
               target="_blank"
@@ -247,7 +248,8 @@ export default function Footer(): ReactElement {
               className="font-medium text-white/80 hover:text-white underline underline-offset-4 transition-colors"
             >
               {frontendImage?.split(":")[1] || "n/a"}
-            </a>{" "}
+            </a>
+            {/*{" "}
             and backend version v
             <a
               href={"https://" + backendImage || "/"}
@@ -256,7 +258,7 @@ export default function Footer(): ReactElement {
               className="font-medium text-white/80 hover:text-white underline underline-offset-4 transition-colors"
             >
               {backendImage?.split(":")[1] || "n/a"}
-            </a>
+            </a>*/}
             ).
           </p>
         </div>


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-559

**📝 PR: Temporarily Disable Backend Display in Footer**
**Summary**
This commit comments out the backend-related version display in the <FooterComponent /> to prevent UI or runtime issues while the backend metadata is not yet available or ready. Frontend version info remains visible.

**Changes**
Commented out:
useState for backendImage
setBackendImage assignment in useEffect
JSX rendering of backend version (with HTML comment block)
Added inline notes to indicate that the backend section can be uncommented once ready

**Files Updated**
next-app/src/components/FooterComponent.tsx:
➕ 8 additions
➖ 6 deletions

**Notes**
This is a non-breaking change aimed at preparing the Footer component for seamless reintegration of backend metadata once the corresponding endpoint becomes stable.

**Author**
👤 @JanProgrammierung 