### PR TITLE
other/536-adding-more-quality-registers

### DIFF
--- a/next-app/src/app/data-sources/quality-registries/page.tsx
+++ b/next-app/src/app/data-sources/quality-registries/page.tsx
@@ -55,6 +55,31 @@ const swedishToEnglishTerms: { [key: string]: string[] } = {
   alzheimer: ["alzheimer", "dementia"],
   demens: ["dementia", "cognitive", "alzheimer"],
   epilepsi: ["epilepsy", "seizure"],
+  epilepsikirurgi: ["epilepsy surgery", "epileptic surgery"],
+  hydrocefalus: ["hydrocephalus", "water on brain"],
+  inflammatoriskpolyneuropati: [
+    "inflammatory polyneuropathy",
+    "chronic inflammatory demyelinating polyneuropathy",
+    "cidp",
+  ],
+  motorneuronsjukdom: [
+    "motor neuron disease",
+    "motor neurone disease",
+    "mnd",
+    "als",
+    "amyotrophic lateral sclerosis",
+  ],
+  myasteniagravis: ["myasthenia gravis", "mg", "muscle weakness"],
+  narkolepsi: ["narcolepsy", "sleep disorder"],
+  neuromuskulärasjukdomar: [
+    "neuromuscular diseases",
+    "neuromuscular disorders",
+  ],
+  svårneurovaskulärhuvudvärk: [
+    "severe neurovascular headache",
+    "cluster headache",
+    "migraine",
+  ],
   astma: ["asthma", "respiratory"],
   artrit: ["arthritis", "rheumatoid"],
   reumatism: ["rheumatism", "rheumatic", "arthritis"],
@@ -130,6 +155,22 @@ const swedishToEnglishTerms: { [key: string]: string[] } = {
   cystiskfibros: ["cystic fibrosis", "cf"],
   myelomeningocele: ["spina bifida", "neural tube defect"],
   neuralrörsdefekt: ["neural tube defect", "spina bifida"],
+
+  // Orthopedic and pediatric conditions
+  höftfyseolys: ["slipped capital femoral epiphysis", "scfe", "hip slippage"],
+  höftledsinstabilitet: [
+    "hip joint instability",
+    "hip dysplasia",
+    "ddh",
+    "developmental dysplasia of hip",
+  ],
+  klumpfot: ["clubfoot", "talipes equinovarus", "peva"],
+  patellaluxation: [
+    "patellar dislocation",
+    "kneecap dislocation",
+    "patella luxation",
+  ],
+  perthes: ["perthes disease", "legg-calve-perthes", "avascular necrosis hip"],
 
   // Registry-specific terms
   kvalitetsregister: ["quality registry", "registry"],

--- a/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
+++ b/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
@@ -235,7 +235,7 @@
         "registry_centre": [
             "Kvalitetsregistercentrum Stockholm"
         ],
-        "url": "https://infcare.com/",
+        "url": "https://qrcstockholm.se/kvalitetsregister/anslutna-register",
         "search_tags": [
             "Sprututbyte",
             "needle exchange",
@@ -926,7 +926,7 @@
             "GynOp",
             "gynecological"
         ],
-        "Information": "Tracks outcomes of gynaecological surgeries, collecting data on patient demographics, surgical methods, complications, and recovery. It covers nearly all hospitals in Sweden performing gynaecological surgeries, offering extensive national coverage to improve surgical outcomes and patient safety.",
+        "Information": "Tracks outcomes of gynaecological surgeries, collecting data on patient demographics, surgical methods, complications, and recovery. It covers nearly all hospitals in Sweden performing gynaecological surgeries, offering extensive national coverage to improve surgical outcomes and patient safety. The register includes the following subregisters: Intrauterin kirurgi; Rekonstruktiv bäckenbottenkirurgi; Inkontinens; Bristning; Hysterektomi, adnex- och endometrioskirurgi",
         "category": [
             "National quality registry"
         ],
@@ -2222,7 +2222,7 @@
         ]
     },
     {
-        "name": "Nationellt kvalitetsregister för KML",
+        "name": "Nationellt kvalitetsregister för KML (kronisk myeloisk leukemi)",
         "registry_centre": [
             "RCC Mellansverige"
         ],
@@ -2366,6 +2366,70 @@
         "start_date": "1997",
         "category": [
             "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationella prostatacancerregistret (NPCR)",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://npcr.se/",
+        "search_tags": [
+            "Nationellt kvalitetsregister för prostatacancer",
+            "prostate cancer"
+        ],
+        "Information": "NPCR collects comprehensive data on diagnostic procedures, disease characteristics, treatment, and outcomes for all men diagnosed with prostate cancer in Sweden. Established to support quality improvement and clinical research, NPCR enables benchmarking across healthcare providers and contributes to evidence-based care.",
+        "start_date": "1987",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister peniscancer (NPECR)",
+        "registry_centre": [
+            "RCC Mellansverige"
+        ],
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/penis.8266.html",
+        "search_tags": [
+            "Nationellt kvalitetsregister för peniscancer",
+            "penis cancer"
+        ],
+        "Information": "NPECR monitors penile cancer care in Sweden, and more than 3,900 patients are included. Over the past six years, the coverage rate has been 88% compared to the Swedish Cancer Register, ensuring that the data is nationwide and population based. The register collects information on disease incidence, diagnostics, tumor stage distribution, morphological classification, treatment, surgical complications, and follow-up. Since 2015, it also includes patient-reported outcome and experience measures and referrals to the national center.",
+        "start_date": "2000",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Nationellt kvalitetsregister för mammografiscreening (NKM)",
+        "registry_centre": [
+            "RCC Väst"
+        ],
+        "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/brostcancerscreening/kvalitetsregister",
+        "search_tags": [
+            "Nationellt kvalitetsregister för mammografiscreening",
+            "breast cancer screening"
+        ],
+        "Information": "NKM monitors the entire breast cancer screening process in Sweden, covering invitation, participation, imaging results, and diagnostic follow-up. Targeting women aged 40–74, the registry also includes referred patients of all ages undergoing breast radiology.",
+        "start_date": "about 2020",
+        "category": [
+            "National cancer quality registry"
+        ]
+    },
+    {
+        "name": "Svenskt bråckregister",
+        "registry_centre": [
+            "Registercentrum Norr"
+        ],
+        "url": "https://www.svensktbrackregister.se/",
+        "search_tags": [
+            "hernia",
+            "inguinal hernia"
+        ],
+        "Information": "The Swedish Hernia Register collects nationwide data on inguinal hernia surgeries in patients aged 15 and older. It supports quality improvement, clinical benchmarking, and research in hernia care across Sweden. As of March 2024, the register has merged with the Swedish Ventral Hernia Register (Registret för Svenska Bukväggsbråck), creating a unified national database for both inguinal and ventral hernia surgeries.",
+        "start_date": "1992",
+        "category": [
+            "National quality registry"
         ]
     }
 ]


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-536
**Add new quality registries and adapted / maintained old ones**
**Add missing neurological and orthopedic medical terms to quality registries search**
Added Swedish-English translations for 13 medical conditions to improve search functionality:
**Neurological conditions:**
Epilepsikirurgi, Hydrocefalus, Inflammatorisk polyneuropati
Motorneuronsjukdom, Myastenia gravis, Narkolepsi
Neuromuskulära sjukdomar, Svår neurovaskulär huvudvärk
**Orthopedic/Pediatric conditions:**
Höftfyseolys, Höftledsinstabilitet, Klumpfot
Patellaluxation, Perthes
These terms are now searchable in both Swedish and English, future-proofing the platform for when relevant quality registries become available.