### PR TITLE
Resolve Dependabot security alerts via npm overrides

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -9025,52 +9025,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -9791,9 +9745,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -9810,7 +9764,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10172,9 +10126,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11636,9 +11590,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12134,14 +12088,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -56,5 +56,11 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^3.4.19",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10",
+    "tmp": "^0.2.6",
+    "qs": "^6.15.2",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Adds an `overrides` block to `next-app/package.json` to pin patched versions of four **transitive** dependencies whose parent packages pin them below the fix. After regenerating the lockfile, `npm audit` reports **0 vulnerabilities** and the existing build/lint/Cypress checks pass unchanged.

| Alert | Package | Before → After | Severity | Source | Scope |
|-------|---------|----------------|----------|--------|-------|
| [#89](https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend/security/dependabot/89) | `tmp` | 0.2.5 → 0.2.7 | **High** — path traversal (CVE-2026-44705) | `cypress` | dev/test |
| [#88](https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend/security/dependabot/88) | `qs` | 6.14.2 → 6.15.2 | Moderate — DoS in `stringify` (CVE-2026-8723) | `cypress › @cypress/request` | dev/test |
| [#87](https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend/security/dependabot/87) | `uuid` | 8.3.2 → 11.1.1 | Moderate — buffer bounds (CVE-2026-41907) | `cypress › @cypress/request` | dev/test |
| [#84](https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend/security/dependabot/84) | `postcss` | 8.4.31 → 8.5.15 | Moderate — XSS via `</style>` (CVE-2026-41305) | `next` (internal pin) | build |

## Why `overrides` (not a plain update)

The parents constrain these below the patched versions, so `npm update` can't reach them:

- `next` pins `postcss` to **`8.4.31`** (exact)
- `@cypress/request` pins `qs` to **`~6.14.1`** (max 6.14.x; fix is 6.15.2)
- `@cypress/request` pins `uuid` to **`^8.3.2`** (fix needs ≥ 11.1.1)
- `cypress` pins `tmp` to `~0.2.3` (in-range, pinned here too for explicitness)

## Compatibility / risk

- `tmp`, `qs`, `uuid` are pulled in **only by Cypress** → never in the production bundle.
- `postcss` here is *next's* internal copy used at **build time** (the project's own top-level `postcss` was already `8.5.x`). 8.4.31 → 8.5.x is a backward-compatible minor.
- The `uuid` **8 → 11 major bump** is safe: `@cypress/request` only uses `const { v4 } = require('uuid')`, and the `v4` named export is unchanged across v8–v14 (v9 only removed the *default* export and deep subpath imports).

## Verification

- ✅ `npm install` — no `ERESOLVE`/peer conflicts
- ✅ `npm ls postcss tmp qs uuid` — only patched versions remain (all `overridden`/`deduped`)
- ✅ `npm audit` — **0 vulnerabilities**
- ✅ `npm run build` — Next production build OK
- ✅ `npm run lint` — clean (only a pre-existing unused-import warning)
- ✅ `npx cypress verify` + load-check of `@cypress/request`/`auth.js` under uuid 11.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)