### PR TITLE
Feature/798 fix pa11y warnings

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -4166,9 +4166,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -4965,9 +4965,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -6050,19 +6050,31 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/framer-motion": {
@@ -7484,9 +7496,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11871,9 +11893,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/next-app/src/app/data-sources/others/layout.tsx
+++ b/next-app/src/app/data-sources/others/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Other Data Sources" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/next-app/src/app/data-sources/others/page.tsx
+++ b/next-app/src/app/data-sources/others/page.tsx
@@ -423,7 +423,7 @@ export default function DataSourcesOthersPage(): ReactElement {
       "Cardiovascular Diseases",
       "Developmental Disorders",
       "Drug Development",
-      "General diseases",
+      "General",
       "Genetic Disorders",
       "Immunological Diseases",
       "Infectious Diseases",

--- a/next-app/src/app/data-sources/others/page.tsx
+++ b/next-app/src/app/data-sources/others/page.tsx
@@ -423,7 +423,7 @@ export default function DataSourcesOthersPage(): ReactElement {
       "Cardiovascular Diseases",
       "Developmental Disorders",
       "Drug Development",
-      "General",
+      "General diseases",
       "Genetic Disorders",
       "Immunological Diseases",
       "Infectious Diseases",

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -22,7 +22,7 @@
     --secondary-foreground: 0 0% 100%;
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted-foreground: 215.4 16.3% 44%;
 
     --accent: 74 60% 55%;
     --accent-foreground: 0 0% 100%;

--- a/next-app/src/app/layout.tsx
+++ b/next-app/src/app/layout.tsx
@@ -36,6 +36,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <title>Precision Medicine Portal</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>

--- a/next-app/src/components/common/FilterSection.tsx
+++ b/next-app/src/components/common/FilterSection.tsx
@@ -32,13 +32,13 @@ export const FilterSection = ({
         {items.map((item) => (
           <div key={item} className="flex items-center space-x-3 mb-4">
             <Checkbox
-              id={`filter-${item}`}
+              id={`filter-${title}-${item}`}
               aria-label={item}
               checked={selectedItems.includes(item)}
               onCheckedChange={() => onFilterChange(item)}
             />
             <label
-              htmlFor={`filter-${item}`}
+              htmlFor={`filter-${title}-${item}`}
               className="text-base leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
             >
               {item} ({getItemCount(item)})

--- a/next-app/src/components/common/FilterSection.tsx
+++ b/next-app/src/components/common/FilterSection.tsx
@@ -33,6 +33,7 @@ export const FilterSection = ({
           <div key={item} className="flex items-center space-x-3 mb-4">
             <Checkbox
               id={`filter-${item}`}
+              aria-label={item}
               checked={selectedItems.includes(item)}
               onCheckedChange={() => onFilterChange(item)}
             />


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-798

Fixes several accessibility issues flagged by pa11y-ci:

- Missing page title: Next.js 15 streams the <title> element asynchronously into the body via JavaScript rather than including it in the initial HTML <head>. Added an explicit <title> to the <head> block in the root layout so it is present in the static HTML before any JavaScript runs.
- Insufficient contrast: --muted-foreground had a contrast ratio of 4.34:1 against --muted backgrounds, just below the WCAG AA threshold of 4.5:1. Lowered the lightness from 46.9% to 44% to bring it to ~4.78:1.
- Checkbox missing accessible name: Radix UI renders checkboxes as <button> elements. The <label for> association is not reliably picked up on buttons by accessibility APIs. Added aria-label directly on the Checkbox component in FilterSection.
- Duplicate element IDs: Two filter sections (dataTypes and diseaseTypes) both contained a filter named "General", producing duplicate id="filter-General" attributes. This also caused a bug where clicking the disease type "General" checkbox would toggle the data type one instead. Fixed by namespacing the id with the section title (e.g. filter-Data types-General).

Also ran npm i and npm audit fix, which is why package-lock is updated.