### PR TITLE
Address dependency-upgrade review feedback

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -1,0 +1,58 @@
+# App CI: install, lint and production-build the Next.js app, then boot
+# the standalone server output (what the Docker image ships) and smoke
+# test key routes. Nothing else in CI compiles the app, so this is the
+# gate that catches unbuildable dependency updates.
+---
+name: App CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  build:
+    name: Lint, build and smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js 26
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: next-app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./next-app
+        run: npm ci
+
+      - name: Lint
+        working-directory: ./next-app
+        run: npm run lint
+
+      - name: Build (production)
+        working-directory: ./next-app
+        run: npm run build
+
+      # Mirrors the Dockerfile's runner stage. /data-sources renders
+      # through security-utils -> isomorphic-dompurify -> jsdom on the
+      # server, so this also guards the documented ERR_REQUIRE_ESM risk
+      # of isomorphic-dompurify v3+ in bundled CommonJS environments.
+      - name: Smoke test standalone server
+        working-directory: ./next-app
+        run: |
+          cp -r public .next/standalone/
+          cp -r .next/static .next/standalone/.next/
+          (cd .next/standalone && PORT=3000 HOSTNAME=127.0.0.1 node server.js &)
+          npx wait-on -t 60000 http://127.0.0.1:3000
+          for path in / /data-sources /contact /omop-cdm /about/team; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:3000$path")
+            echo "$path -> $code"
+            [ "$code" = "200" ] || exit 1
+          done

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -2,7 +2,9 @@
 # The config file and sitemap file used by this workflow
 # are in the ".github" directory of the repository
 #
-# This runs against a local instance of the app
+# This runs against a local production build of the app (a dev-mode
+# server compiles pages on demand, which made the data-heavy pages
+# exceed pa11y's 30s wait and fail the run)
 ---
 name: Pa11y Accessibility Check
 
@@ -16,25 +18,32 @@ jobs:
   pa11y:
     name: Pa11y Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js 26
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 26
+          cache: npm
+          cache-dependency-path: next-app/package-lock.json
 
       - name: Install dependencies
         working-directory: ./next-app
-        run: npm install
+        run: npm ci
+
+      - name: Build app
+        working-directory: ./next-app
+        run: npm run build
 
       - name: Start app and wait until ready
         working-directory: ./next-app
         run: |
-          npm run dev &
-          npx wait-on http://127.0.0.1:3000
+          npm run start &
+          npx wait-on -t 120000 http://127.0.0.1:3000
 
       - name: Run Pa11y CI
         working-directory: ./next-app
@@ -47,7 +56,7 @@ jobs:
 
       - name: Upload Pa11y results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pa11y-results
           path: .github/pa11y-results.txt

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -20,9 +20,9 @@
           security-events: write
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@master
+          - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
           - name: Run Snyk to check for vulnerabilities
-            uses: snyk/actions/node@master
+            uses: snyk/actions/node@8e119fbb6c251787721d34ba683ed48eba792766 # master as of 2026-05-27; no current release tag
             continue-on-error: true # To make sure that SARIF upload gets called
             env:
               SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -30,7 +30,7 @@
               command: code test
               args: --sarif-file-output=snyk.sarif
           - name: Upload result to GitHub Code Scanning
-            uses: github/codeql-action/upload-sarif@v4
+            uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
             with:
               sarif_file: snyk.sarif
               category: snyk

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -19,10 +19,10 @@
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v7
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     
           - name: Run Trivy vulnerability scanner
-            uses: aquasecurity/trivy-action@master
+            uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
             with:
               scan-type: "fs"
               ignore-unfixed: true
@@ -31,7 +31,7 @@
               severity: "CRITICAL,HIGH"
     
           - name: Upload Trivy scan results to GitHub Security tab
-            uses: github/codeql-action/upload-sarif@v4
+            uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
             with:
               sarif_file: "trivy-results.sarif"
               category: trivy

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Builds the app for production using Next.js optimization.\
 The build is minified and optimized for the best performance.\
 This also checks the linting.
 
+Note: production builds currently pass `--webpack` to opt out of Next 16's
+Turbopack default; this was kept during the Next 16 upgrade to minimize
+change (development mode already uses Turbopack). A Turbopack production
+build compiles cleanly, so the flag can likely be dropped after a verified
+visual comparison — tracked as a follow-up.
+
 ###### `npm start`
 
 Starts the production server after building the app.

--- a/next-app/eslint.config.mjs
+++ b/next-app/eslint.config.mjs
@@ -10,7 +10,11 @@ const eslintConfig = [
   {
     settings: {
       react: {
-        version: "19.2.5",
+        // Hardcoded because eslint-plugin-react's automatic version
+        // detection crashes under ESLint 10 (its detect path still calls
+        // the removed context.getFilename API). Remove once the plugin
+        // bundled by eslint-config-next supports ESLint 10 detection.
+        version: "19",
       },
     },
     rules: {

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -22,7 +22,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cookies-next": "^6.0.0",
-        "dompurify": "^3.4.0",
         "framer-motion": "^12.38.0",
         "isomorphic-dompurify": "^3.0.0",
         "js-cookie": "^3.0.5",
@@ -42,7 +41,6 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.2",
-        "@types/dompurify": "^3.2.0",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "26.1",
         "@types/react": "^19.2.14",
@@ -4569,17 +4567,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "*"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -23,7 +23,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cookies-next": "^6.0.0",
-    "dompurify": "^3.4.0",
     "framer-motion": "^12.38.0",
     "isomorphic-dompurify": "^3.0.0",
     "js-cookie": "^3.0.5",
@@ -43,7 +42,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.2",
-    "@types/dompurify": "^3.2.0",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "26.1",
     "@types/react": "^19.2.14",

--- a/next-app/src/global.d.ts
+++ b/next-app/src/global.d.ts
@@ -1,1 +1,0 @@
-declare module "*.css" {}

--- a/next-app/src/lib/security-utils.ts
+++ b/next-app/src/lib/security-utils.ts
@@ -1,4 +1,4 @@
-import createDOMPurify from "isomorphic-dompurify";
+import DOMPurify from "isomorphic-dompurify";
 import validator from "validator";
 
 /**
@@ -20,10 +20,11 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
   allowedFilenameChars: /[^a-zA-Z0-9_-]/g,
 };
 
-// Initialize DOMPurify for both client and server environments
-const DOMPurify = createDOMPurify(
-  typeof window !== "undefined" ? window : undefined
-);
+// isomorphic-dompurify's default export is already initialized for the
+// current environment: bound to a jsdom window on the server and to the
+// real window in the browser. Calling it as a factory with `undefined`
+// (as this module previously did) yields an instance without a working
+// `sanitize` on the server.
 
 /**
  * Sanitizes URLs to prevent DOMXSS and protocol-based attacks

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -29,6 +29,7 @@
     "target": "ES2017"
   },
   "include": [
+    "next-env.d.ts",
     "src",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"]
 }


### PR DESCRIPTION
Implements the review feedback on the recent Renovate dependency upgrades. Each item was verified before changing anything; two items turned out to need different fixes than suggested.

## Important items

**1. Security workflows used mutable @master refs** — All actions in the Snyk and Trivy workflows are now pinned to commit SHAs (release tags where current; `snyk/actions/node` pins current master because its latest release is 8 months behind). `renovate.json` now extends `config:recommended` + `helpers:pinGitHubActionDigests`, so Renovate maintains the digests and will pin the remaining workflows (e.g. the container publish workflow) in an automated follow-up PR.

**2. No CI ran install/lint/build** — New **App CI** workflow: Node 26, `npm ci`, `npm run lint`, `npm run build`, then it boots the **standalone server output** (exactly what the Docker image ships) and smoke tests `/`, `/data-sources`, `/contact`, `/omop-cdm`, `/about/team` for HTTP 200. Consider making it a required check in branch protection (needs repo settings access).

**3. isomorphic-dompurify v3 ESM risk** — Investigation found a deeper bug: `security-utils.ts` called the default export as a factory with `undefined` on the server, yielding an instance with `isSupported=false` and **no `sanitize` method** (server-side sanitize calls would throw). It only never crashed because the data-source cards render client-side. Fixed to use the environment-bound default instance directly — server-side sanitization now actually works (verified in Node: strips `onerror` handlers). The App CI smoke test covers the ERR_REQUIRE_ESM import risk, since `/data-sources` SSRs through security-utils → isomorphic-dompurify → jsdom in the standalone bundle. Also removed the direct `dompurify` + deprecated `@types/dompurify` deps — nothing imports them.

**4. tsconfig / CSS shim** — `next-env.d.ts` is now in `include`; `src/global.d.ts` (`declare module "*.css"`) deleted — it duplicated `next/types/global.d.ts:45`. Verified with `tsc --noEmit` and a full build.

## Minor items

**ESLint React version pin** — Verified it is load-bearing, not cosmetic: without it, ESLint 10 crashes (`contextOrFilename.getFilename is not a function` in eslint-plugin-react's version detection). Kept with an explanatory comment and coarsened `"19.2.5"` → `"19"` so it doesn't rot on patch bumps.

**`next build --webpack`** — Documented in the README: kept during the Next 16 upgrade to minimize change; dev mode already runs Turbopack. A Turbopack production build compiles cleanly today, so dropping the flag is a viable follow-up after a screenshot-diff verification (same method used for the Tailwind v4 migration).

## Bonus (Pa11y reliability)

Pa11y now tests a **production build** instead of `next dev`: dev-mode on-demand compilation made the three data-heavy pages exceed pa11y's 30s wait (12/15 URLs on every recent run), while a production server passes 15/15 (verified locally, twice). The job also gets a 30-minute timeout so a non-booting server fails fast instead of hanging 6 hours, as happened on the unadapted Tailwind/TS7 branches.

## Verification

- `npm run lint`: passes (same 3 pre-existing warnings)
- `npm run build` + `tsc --noEmit`: pass
- Standalone server smoke run locally: all 5 routes return 200
- Node-level red/green probe for the DOMPurify fix (broken factory instance vs working bound instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)