### PR TITLE
Build production bundles with Turbopack

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,6 @@ Builds the app for production using Next.js optimization.\
 The build is minified and optimized for the best performance.\
 This also checks the linting.
 
-Note: production builds currently pass `--webpack` to opt out of Next 16's
-Turbopack default; this was kept during the Next 16 upgrade to minimize
-change (development mode already uses Turbopack). A Turbopack production
-build compiles cleanly, so the flag can likely be dropped after a verified
-visual comparison — tracked as a follow-up.
-
 ###### `npm start`
 
 Starts the production server after building the app.

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint ."
   },


### PR DESCRIPTION
Follow-up from #237: drops `--webpack` from `npm run build`, adopting Next 16's Turbopack default for production builds. Development mode already ran Turbopack, so this removes the dev/prod bundler divergence rather than introducing change.

## Verification

- **Visual**: full-page screenshots of 6 representative pages (home, data-sources, FAQ, contact, team, omop-cdm), webpack vs Turbopack builds captured in the same browser session, pixel-diffed: identical page heights everywhere; five pages 0.0000% difference; home differs only inside the two hero-card dashboard images (known `next/image` re-encoding noise between any two builds — all text/layout rows are zero-diff).
- **Accessibility**: `pa11y-ci` against the Turbopack production server: 15/15 URLs pass.
- **Deployment shape**: `.next/standalone` + `.next/static` are produced as before; the standalone server boots and serves `/`, `/data-sources`, `/contact`, `/omop-cdm`, `/about/team` with 200 (same checks as the App CI smoke step, which also runs on this PR).
- README's temporary note about the flag is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)