### PR TITLE
Remove dev branch references after moving to a single-branch flow

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -7,9 +7,9 @@ name: App CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -10,9 +10,9 @@ name: Pa11y Accessibility Check
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   pa11y:

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -6,10 +6,10 @@
     
     on:
       push:
-        branches: ["dev", main]
+        branches: [main]
       pull_request:
         # The branches below must be a subset of the branches above
-        branches: ["dev"]
+        branches: [main]
       schedule:
         - cron: "0 7,13 * * *"
     

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -9,7 +9,6 @@
       push:
         branches:
           - main
-          - dev
     jobs:
       scan:
         permissions:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Please note that we require all commits to be verified, so you must sign your co
 Fetch changes at any time from this remote:
 
 ```bash
-git pull upstream dev
+git pull upstream main
 ```
 
 #### Step 2: Set up your development environment
@@ -192,7 +192,7 @@ git add my_changed_file
 
 You can then commit and push to your branch:
 
-(NOTE: DO NOT FORGET TO SIGN YOUR COMMITS, by policy only signed commits can be merged into the main branches.)
+(NOTE: DO NOT FORGET TO SIGN YOUR COMMITS, by policy only signed commits can be merged into the main branch.)
 
 ```bash
 git commit -S -m "My commit"


### PR DESCRIPTION
## Summary

The `dev` branch was deleted — the project's scope no longer justifies a two-branch flow. This cleans up everything in the repo that still referenced it:

- **`snyk-scan.yml`** — the `pull_request` trigger was filtered to PRs targeting `dev`, so Snyk would never have run on a PR again (only the cron and pushes to main). Now filters on `main`; also removed `dev` from the push trigger. **This was the only functional break.**
- **`app-ci.yml`, `pa11y.yml`, `trivy-scan.yml`** — removed `dev` from push/PR branch filters (stale but harmless).
- **`README.md`** — contributor instructions: `git pull upstream dev` → `git pull upstream main`, and "main branches" → "main branch".

Not touched (verified unaffected): `publish_container_image.yml` triggers on `v*.*.*` tags only, and `renovate.json` has no `baseBranches` override so Renovate follows the default branch, which is already `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)