### PR TITLE
ci: harden container supply chain (digest-pin base, SBOM/provenance, image scan)

### DIFF
--- a/.github/workflows/publish_container_image.yml
+++ b/.github/workflows/publish_container_image.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write # upload the Trivy image-scan SARIF to the Security tab
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -54,6 +55,7 @@ jobs:
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
       - name: Build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           push: true
@@ -62,3 +64,32 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata_action_id.outputs.tags }}
           labels: ${{ steps.metadata_action_id.outputs.labels }}
+          # Supply-chain attestations, pushed alongside the image to GHCR:
+          #   provenance (SLSA, mode=max) records how/where/from-which-commit
+          #   the image was built; sbom records what is inside it.
+          provenance: mode=max
+          sbom: true
+
+      # Scan the artifact we actually ship. The pre-build Trivy "fs" scan
+      # (trivy-scan.yml) only sees the source tree, not the base-OS packages
+      # or the production node_modules baked into the final image. This is
+      # report-only (Trivy's default exit-code is 0), so a newly disclosed
+      # upstream CVE never blocks a release; findings surface in the Security
+      # tab. The image is referenced by the digest just pushed, and by a
+      # lowercased name because OCI/GHCR require lowercase repository names.
+      - name: Scan the published image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/scilifelabdatacentre/precision-medicine-portal@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-image-results.sarif
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+
+      - name: Upload image-scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: trivy-image-results.sarif
+          category: trivy-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:26-alpine AS base
+# Pinned by digest for reproducible builds; the tag is kept for readability.
+# Renovate maintains both the tag and the digest (see renovate.json). The
+# digest is the multi-arch image index, so amd64 + arm64 builds are preserved.
+FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS base
 
 # 1. Install dependencies only when needed
 FROM base AS deps

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "docker": {
+    "pinDigests": true
+  }
 }


### PR DESCRIPTION
## Summary

Implements the **"Harden the supply chain"** feedback (Impact: Medium · Effort: S · Risk: Low). Three focused changes, all additive — none change how the app runs.

### 1. Reproducible builds — pin the base image by digest
- `Dockerfile` now uses `node:26-alpine@sha256:e88a35be…` (the **multi-arch OCI image index**, so amd64 + arm64 are both preserved), keeping the tag for readability.
- Enabled **Renovate `docker.pinDigests`** in `renovate.json` so it maintains the digest (and tag) automatically — the same digest-pinning discipline the repo already applies to its GitHub Actions.

### 2. Attest the published image — SBOM + provenance
- Added `provenance: mode=max` and `sbom: true` to the `docker/build-push-action` step. Both attestations are pushed to GHCR alongside the image.
  - **Provenance (SLSA, `mode=max`)** — signed record of *how / where / from which commit* the image was built. I used `mode=max` rather than a bare `true` because it includes the full build definition and materials, which is what makes provenance actually verifiable (bare `true` = `mode=min` is minimal).
  - **SBOM** — machine-readable inventory of what's inside the image, so "is CVE-X in what we shipped?" is answerable directly.

### 3. Scan the artifact we actually ship
- Added a post-build **Trivy image scan**, referenced by the digest just pushed (`steps.build.outputs.digest`). The existing `trivy-scan.yml` only scans the **source tree** (`scan-type: fs`) — it never sees the base-OS packages or the production `node_modules` baked into the final image.
- **Report-only** (Trivy's default `exit-code: 0`): CRITICAL/HIGH findings upload to the Security tab under a distinct category (`trivy-image`); a newly disclosed upstream CVE never blocks a release. Added `security-events: write` for the SARIF upload and `limit-severities-for-sarif: true` to keep the Security tab focused.

**On report-only vs blocking** (you asked): I did *not* strongly recommend blocking, so report-only stands. This workflow triggers on **release tags** and is **multi-arch**, so the image is pushed in the same buildx step it's built — a scan there necessarily runs *after* the push. A hard gate wouldn't actually stop a vulnerable image from reaching the registry; it would only redden the release run while coupling "can we release" to "did Alpine disclose a CVE in the last hour." Report-only delivers the alerting value without that friction. The right place for a hard gate is a *pre-merge* image build on PRs — happy to add that as a follow-up if you want enforcement.

## Verification
- `actionlint` on the workflow → **clean** (also shellchecks run steps and validates the `${{ steps.build.outputs.digest }}` reference)
- Pinned digest resolves to the `node:26-alpine` **OCI image index** (`docker buildx imagetools inspect`)
- `renovate.json` and the workflow YAML both parse

## Notes / heads-up
- Enabling attestations makes the pushed image an OCI index that also carries attestation manifests. Modern Docker/containerd/Kubernetes handle this transparently; worth a sanity check that your deploy/pull path is on a current runtime (it is, for standard `docker pull` / K8s).
- Base is `chore/setup-improvements` (sibling of the tests PR #258, independent of it) since the publish workflow's tag-guard and `renovate.json`'s `minimumReleaseAge` live there, not on `main`. Retarget if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)