### PR TITLE
Fix header responsiveness, image aspect ratios, dev CSP, and profile wrapping

### DIFF
--- a/next-app/next.config.mjs
+++ b/next-app/next.config.mjs
@@ -12,9 +12,16 @@
 // add https://www.google.com and https://www.gstatic.com to script-src,
 // https://www.google.com to a frame-src directive, and
 // https://forms.dc.scilifelab.se to form-action.
+// React's development build uses eval() for debugging (e.g. reconstructing
+// call stacks). `next dev` serves this same CSP, so without 'unsafe-eval' in
+// development the browser blocks it and logs a CSP error. Production never
+// needs it — React's prod build has no eval() — so it is kept out of the
+// shipped policy. This dev/prod split follows the Next.js CSP guide.
+const isDev = process.env.NODE_ENV === "development";
+
 const cspDirectives = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://matomo.dc.scilifelab.se",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://matomo.dc.scilifelab.se`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' blob: data: https://matomo.dc.scilifelab.se",
   "font-src 'self'",

--- a/next-app/src/app/about/dsnpmd-projects/page.tsx
+++ b/next-app/src/app/about/dsnpmd-projects/page.tsx
@@ -129,13 +129,16 @@ export default function AboutDSNPMDProjectsPage() {
                   </div>
 
                   {project.logoKey && logos[project.logoKey] && (
-                    <div className="shrink-0" aria-hidden="true">
+                    <div
+                      className="relative h-16 w-32 shrink-0"
+                      aria-hidden="true"
+                    >
                       <Image
                         src={logos[project.logoKey]}
                         alt=""
-                        width={128}
-                        height={64}
-                        className="object-contain max-h-[64px]"
+                        fill
+                        sizes="128px"
+                        className="object-contain"
                         role="presentation"
                       />
                     </div>

--- a/next-app/src/app/about/partners/page.tsx
+++ b/next-app/src/app/about/partners/page.tsx
@@ -124,12 +124,15 @@ export default function AboutPartnersPage() {
                     </CardTitle>
                   </div>
 
-                  <div className="shrink-0" aria-hidden="true">
+                  <div
+                    className="relative h-16 w-32 shrink-0"
+                    aria-hidden="true"
+                  >
                     <Image
                       src={logos[partner.logoKey]}
                       alt=""
-                      width={128}
-                      height={64}
+                      fill
+                      sizes="128px"
                       className="object-contain"
                       role="presentation"
                     />

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -1,5 +1,5 @@
 /* Limit class detection to the app sources (parity with the v3 `content` globs). */
-@import 'tailwindcss' source('..');
+@import "tailwindcss" source("..");
 
 @theme {
   --color-background: hsl(var(--background));
@@ -52,6 +52,13 @@
 
   --font-sans: var(--font-lato), sans-serif;
 
+  /* Custom breakpoint for the header: the horizontal desktop nav needs ~1130px
+     to fit alongside the logo (logo ~484px at h-12 + 5 items ~581px +
+     gaps/padding). Below this we show the hamburger. Tuned above the fit width
+     for margin; revisit if nav items or the logo height change. Enables the
+     `navbar:` variant. */
+  --breakpoint-navbar: 72rem;
+
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
 
@@ -69,6 +76,23 @@
     }
     to {
       height: 0;
+    }
+  }
+
+  /* Fast, subtle reveal for the header navigation dropdowns (see
+     NavigationMenuViewport). Added because the tailwindcss-animate classes the
+     shadcn primitive ships with became inert after the Tailwind v4 migration,
+     so the menus previously had no open animation at all. */
+  --animate-nav-open: nav-open 120ms ease-out;
+
+  @keyframes nav-open {
+    from {
+      opacity: 0;
+      transform: scale(0.97) translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
     }
   }
 }

--- a/next-app/src/app/omop-cdm/page.tsx
+++ b/next-app/src/app/omop-cdm/page.tsx
@@ -311,7 +311,7 @@ export default function OMOPCDMPage(): ReactElement {
           <div className="flex flex-col gap-8 text-left md:flex-row md:gap-16 md:justify-between md:items-center">
             <div className="w-full md:w-1/2 flex flex-col gap-4">
               <Image
-                className="object-contain"
+                className="mx-auto w-full h-auto"
                 src="/img/omop/omop-timeline.png"
                 alt="What's the history of OMOP?"
                 width={500}
@@ -319,7 +319,7 @@ export default function OMOPCDMPage(): ReactElement {
                 priority
               />
               <Image
-                className="object-contain"
+                className="mx-auto w-full h-auto"
                 src="/img/omop/ohdsi-collaborators-july2025.png"
                 alt="OHDSI Collaborators July 2025"
                 width={500}

--- a/next-app/src/components/HeaderComponent.tsx
+++ b/next-app/src/components/HeaderComponent.tsx
@@ -87,13 +87,13 @@ export default function HeaderComponent() {
             src={"/scilifelab-logo/precisionmedicineportal-logo-white.png"}
             alt="Precision Medicine Portal - SciLifeLab"
             priority
-            className="w-auto h-7 lg:h-14"
+            className="w-auto h-7 navbar:h-12"
           />
         </Link>
-        <div className="hidden lg:block">
+        <div className="hidden navbar:block">
           <DesktopNav />
         </div>
-        <div className="lg:hidden">
+        <div className="navbar:hidden">
           <MobileNav />
         </div>
       </div>
@@ -103,7 +103,7 @@ export default function HeaderComponent() {
 
 function DesktopNav() {
   return (
-    <NavigationMenu>
+    <NavigationMenu delayDuration={0}>
       <NavigationMenuList role="menubar" aria-label="Main navigation">
         <NavigationMenuItem role="none">
           <NavigationMenuTrigger aria-label="Data sources menu">

--- a/next-app/src/components/ProfileComponent.tsx
+++ b/next-app/src/components/ProfileComponent.tsx
@@ -18,28 +18,22 @@ const ProfileComponent: React.FC<ProfileComponentProps> = ({
 }) => {
   return (
     <article
-      className={`flex flex-row items-center p-4 transition-all duration-500 hover:bg-base-100 hover:shadow-lg ${bgColor}`}
+      className={`flex flex-row items-center gap-4 p-4 transition-all duration-500 hover:bg-base-100 hover:shadow-lg ${bgColor}`}
       role="listitem"
       aria-label={`Profile of ${name}`}
     >
-      <div className="flex items-center lg:p-2 lg:w-1/3">
-        <div className="relative w-24 h-24 lg:w-32 lg:h-32 rounded-full overflow-hidden">
-          <Image
-            src={imageUrl}
-            alt={`Profile photo of ${name}`}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 96px, 128px"
-          />
-        </div>
-        <div className="text-left lg:w-2/3 pl-4">
-          <h2 className="text-2xl text-ellipsis lg:text-5xl lg:text-nowrap font-normal">
-            {name}
-          </h2>
-          <p className="text-lg lg:text-xl lg:text-nowrap italic pt-2">
-            {title}
-          </p>
-        </div>
+      <div className="relative h-24 w-24 shrink-0 overflow-hidden rounded-full lg:h-32 lg:w-32">
+        <Image
+          src={imageUrl}
+          alt={`Profile photo of ${name}`}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 96px, 128px"
+        />
+      </div>
+      <div className="min-w-0 flex-1 text-left">
+        <h2 className="text-2xl font-normal break-words lg:text-5xl">{name}</h2>
+        <p className="pt-2 text-lg italic break-words lg:text-xl">{title}</p>
       </div>
     </article>
   );

--- a/next-app/src/components/ui/navigation-menu.tsx
+++ b/next-app/src/components/ui/navigation-menu.tsx
@@ -13,7 +13,7 @@ const NavigationMenu = React.forwardRef<
     ref={ref}
     className={cn(
       "relative z-10 flex max-w-max flex-1 items-center justify-center",
-      className
+      className,
     )}
     {...props}
   >
@@ -31,7 +31,7 @@ const NavigationMenuList = React.forwardRef<
     ref={ref}
     className={cn(
       "group flex flex-1 list-none items-center justify-center space-x-1",
-      className
+      className,
     )}
     {...props}
   />
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral hover:text-neutral-foreground focus:bg-neutral focus:text-neutral-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-neutral/50 data-[state=open]:bg-neutral/50"
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-neutral hover:text-neutral-foreground focus:bg-neutral focus:text-neutral-foreground focus:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-active:bg-neutral/50 data-[state=open]:bg-neutral/50",
 );
 
 const NavigationMenuTrigger = React.forwardRef<
@@ -70,7 +70,7 @@ const NavigationMenuContent = React.forwardRef<
     ref={ref}
     className={cn(
       "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto ",
-      className
+      className,
     )}
     {...props}
   />
@@ -86,8 +86,8 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-(--radix-navigation-menu-viewport-width)",
-        className
+        "origin-top-center relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-nav-open md:w-(--radix-navigation-menu-viewport-width)",
+        className,
       )}
       ref={ref}
       {...props}
@@ -105,7 +105,7 @@ const NavigationMenuIndicator = React.forwardRef<
     ref={ref}
     className={cn(
       "top-full z-1 flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
-      className
+      className,
     )}
     {...props}
   >


### PR DESCRIPTION
## Summary

Frontend responsiveness fixes and polish, each verified in a real browser across widths (375 / 768 / 1024 / 1152 / 1280px) and with a full `build` + `test` + `lint` + `typecheck` pass.

## Changes

**`fix(header)` — responsive nav + faster dropdowns**
- The desktop nav switched to horizontal at `lg` (1024px) but the oversized logo (`h-14`, ~565px wide) meant it didn't fit until ~1200px, so the rightmost links were silently **clipped** by `html { overflow-x: clip }`. Right-sized the logo to `h-12` (~488px) and moved the desktop↔hamburger switch to a custom `navbar` breakpoint (72rem/1152px) tuned to where the nav actually fits. No clipping at any width; hamburger below the breakpoint.
- Dropdowns now open instantly on hover (`delayDuration={0}`) with a real 120ms reveal animation. The `tailwindcss-animate` classes the shadcn primitive shipped were **inert** after the Tailwind v4 migration (they generate no CSS), so the menus had no open animation at all; a lightweight `nav-open` keyframe replaces them.

**`fix(team)` — profile name overflow**
- `ProfileComponent`'s text column was nested inside the image's `lg:w-1/3` (only ~235px wide), and `lg:text-nowrap` forced long names onto one line (`text-ellipsis` was inert without `overflow-hidden`), so names overflowed. Flattened to image + text siblings (`flex-1 min-w-0`), dropped `lg:text-nowrap`, added `break-words` so names wrap at every width.

**`fix(images)` — aspect-ratio warnings**
- `next/image` logged aspect-ratio warnings because Tailwind v4 Preflight sets `img { height: auto }`, overriding the `height` prop so only one axis was constrained. Partner logos (Partners + DSN-PMD Projects) now use `fill` + `sizes` in a fixed 128×64 box; the two OMOP diagrams use `mx-auto w-full h-auto` to match their siblings. Dev-only warning, no production impact — removes console noise and latent overflow.

**`fix(csp)` — dev-only `unsafe-eval`**
- React's development build uses `eval()` for debugging, so `next dev` (which serves the CSP) logged a Content-Security-Policy error. Gated `'unsafe-eval'` behind `NODE_ENV === "development"`; the shipped production policy is byte-for-byte unchanged. Follows the Next.js CSP guide.

## Verification

- `next build`: exit 0 (21 routes, still static)
- `vitest`: 44/44 pass
- `eslint .` / `tsc --noEmit` / `prettier --check`: clean
- Production CSP confirmed to **not** contain `unsafe-eval`
- Header, Team, and content pages measured to have zero horizontal overflow at 375/1024/1152/1280px

## Notes

- The custom `navbar` breakpoint is documented inline in `globals.css`; revisit its value if nav items or the logo height change.
- `package-lock.json` is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
