### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "precision-medicine-portal-frontend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "precision-medicine-portal-frontend",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precision-medicine-portal-frontend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Release 1.3.0

Bumps `next-app/package.json` (and `package-lock.json` version fields) **1.2.2 → 1.3.0**. Minor release — new features + security + maintenance, backward-compatible.

> `package-lock.json` was updated with **npm 11** so the `@next/swc` `libc` metadata is preserved (repo pins Node 26); the diff is version fields only.

### Highlights since v1.2.2 (20 PRs)

**Features / UX**
- Responsive header fix + faster nav dropdowns, image aspect-ratio corrections, profile-name wrapping (#265, #268-adjacent)

**Security**
- HTTP security headers + Content-Security-Policy, self-hosted fonts; dev-gated `unsafe-eval`
- `sharp` → ^0.35.3 (libvips CVEs) and `brace-expansion` ReDoS patched (#266)
- Snyk `javascript/DOMXSS` false-positive documented + DOM-XSS sweep (#267)
- Supply-chain hardening

**Maintenance**
- Prettier 3 repo-wide reformat (#268); added Vitest tests + `typecheck`
- Dependency updates: React 19, Next 16, Tailwind 4, Radix UI, isomorphic-dompurify 3, lucide, and CI actions

### Release checklist (post-merge)
`publish_container_image.yml` triggers on a `v*.*.*` tag push and **verifies the tag equals `package.json` version**, so:
1. Merge this PR.
2. Tag the merge commit `v1.3.0` and push it → builds & publishes the container image (+ Trivy scan).
3. Create the GitHub Release **"Version 1.3.0"** for `v1.3.0`.

### Verification
`format:check` clean · `eslint` clean · `tsc --noEmit` clean · `vitest` 44/44 · `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
