### PR TITLE
chore: complete rename to precision-medicine-portal

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ title: "Precision Medicine Portal frontend"
 version: 1.1.4
 date-released: 2026-02-27
 url: "https://precision-medicine-portal.scilifelab.se"
-repository-code: "https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend"
+repository-code: "https://github.com/ScilifelabDataCentre/precision-medicine-portal"
 license: MIT
 keywords:
   - Precision Medicine Portal

--- a/README.md
+++ b/README.md
@@ -107,17 +107,17 @@ next-app/
 
 **Important**: You must work through a fork of the repository. Do not commit directly to the main repository.
 
-1. Fork the repository: Click the "Fork" button at the top right of the [main repository page](https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend) to create your own copy.
+1. Fork the repository: Click the "Fork" button at the top right of the [main repository page](https://github.com/ScilifelabDataCentre/precision-medicine-portal) to create your own copy.
 
 2. Clone your fork: Clone your forked repository to your local machine:
 
    ```bash
-   git clone https://github.com/YOUR_USERNAME/precision-medicine-portal-frontend.git
+   git clone https://github.com/YOUR_USERNAME/precision-medicine-portal.git
    ```
 
 3. Add the upstream remote: Add the original repository as an upstream remote to keep your fork updated:
    ```bash
-   git remote add upstream https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend.git
+   git remote add upstream https://github.com/ScilifelabDataCentre/precision-medicine-portal.git
    ```
 
 Please note that we require all commits to be verified, so you must sign your commits. For information on how to set this up, see the GitHub documentation [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
@@ -222,7 +222,7 @@ Once you're finished with your edits and they are committed and pushed to your b
 
 You can find full documentation on the [GitHub help website](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). In short:
 
-- Visit your fork: `https://github.com/YOUR_USERNAME/precision-medicine-portal-frontend`
+- Visit your fork: `https://github.com/YOUR_USERNAME/precision-medicine-portal`
 - Find the branch `my_branch` that you created and pushed to
 - Click the button that reads _"New Pull Request"_
 - GitHub will automatically detect that you want to create a pull request to the upstream repository

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "precision-medicine-portal-frontend",
+  "name": "precision-medicine-portal",
   "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "precision-medicine-portal-frontend",
+      "name": "precision-medicine-portal",
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "precision-medicine-portal-frontend",
+  "name": "precision-medicine-portal",
   "version": "1.3.0",
   "private": true,
   "license": "MIT",

--- a/next-app/src/components/FooterComponent.tsx
+++ b/next-app/src/components/FooterComponent.tsx
@@ -290,7 +290,7 @@ export default function Footer(): ReactElement {
             Built by the Data Science Node in Precision Medicine and
             Diagnostics. The source code is available on{" "}
             <a
-              href="https://github.com/ScilifelabDataCentre/precision-medicine-portal-frontend"
+              href="https://github.com/ScilifelabDataCentre/precision-medicine-portal"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-white/80 hover:text-white underline underline-offset-4 transition-colors"


### PR DESCRIPTION
Aligns the remaining in-repo references to the new repo/deployment name `precision-medicine-portal` (from `…-frontend`): package.json `name` (+ lockfile name fields, synced under npm 11 so `libc` is preserved), README URLs, CITATION.cff `repository-code`, and the footer source-code link. The container package name is already correct in `publish_container_image.yml`, so this is references-only — no build/behaviour change. Verified: format/lint/typecheck clean, 44/44 tests, `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)