### PR TITLE
chore(release): 1.3.1

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "precision-medicine-portal",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "precision-medicine-portal",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precision-medicine-portal",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Release 1.3.1

Bumps `next-app/package.json` (and `package-lock.json` version fields) **1.3.0 → 1.3.1**. Patch release — dependency/CI maintenance only, no application features or behavior changes.

> `package-lock.json` was updated with npm 11 so the `@next/swc` `libc` metadata is preserved (repo pins Node 26); the diff is version fields only.

### Highlights since v1.3.0 (13 PRs, all Renovate dependency/CI maintenance)

**Dependencies (within existing package.json semver ranges)**
- React 19.2 / React DOM, Next.js 16.2.12, Radix UI primitives monorepo, framer-motion 12.43.0, isomorphic-dompurify 3.21.0, lucide-react 1.28.0, @socialgouv/matomo-next 1.14.2, eslint 10.8.0, @types/node 26.1.2 (#284, #280, #275, #282, #283, #278, #277, #279, #281)

**CI / Infrastructure**
- `github/codeql-action` digest bump to v4.37.4 (#274)
- `docker/login-action` digest bump (#273)
- `node:26-alpine` base image digest refresh — verified locally with an actual `docker build` + container smoke test before merging (#276)
- `renovate.json` migrated to the current `packageRules` schema (#272)

### Release checklist (post-merge)
`publish_container_image.yml` triggers on a `v*.*.*` tag push and **verifies the tag equals `package.json` version**, so:
1. Merge this PR.
2. Tag the merge commit `v1.3.1` and push it → builds & publishes the container image (+ Trivy scan).
3. Create the GitHub Release **"Version 1.3.1"** for `v1.3.1`.

### Verification
`format:check` clean · `eslint` clean · `tsc --noEmit` clean · `vitest` 44/44 · `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)