### PR TITLE
fix(security): remediate all 12 Dependabot and 5 code-scanning alerts

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-config-next": "^16.0.0",
         "eslint-config-prettier": "^10.1.8",
         "pa11y-ci": "^4.1.1",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.23",
         "prettier": "^3.9.6",
         "tailwindcss": "^4.3.2",
         "typescript": "^6.0.0",
@@ -625,16 +625,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -3521,16 +3521,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -4608,9 +4608,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4843,9 +4843,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5327,9 +5327,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7035,9 +7035,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7561,9 +7561,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -8216,6 +8216,24 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/napi-postinstall": {
@@ -8973,9 +8991,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -8992,30 +9010,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -10525,9 +10525,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -48,7 +48,7 @@
     "eslint-config-next": "^16.0.0",
     "eslint-config-prettier": "^10.1.8",
     "pa11y-ci": "^4.1.1",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.23",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.0",
@@ -56,7 +56,7 @@
     "wait-on": "^9.0.10"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.3"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchCategories": ["docker"],
       "pinDigests": true
+    },
+    {
+      "description": "minimumReleaseAge cannot be enforced for lock file maintenance: the package manager resolves the versions itself, so Renovate has no per-release age to check. Left as null rather than an unenforceable 7 days.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
## Summary

Clears **all 17 open security alerts** — 12 Dependabot + 5 Trivy code-scanning. `npm audit`: **8 vulnerabilities (5 high, 3 moderate) → 0**.

### Root cause

All 17 alerts were one class of defect: **stale in-range resolutions in `package-lock.json`**. Every parent range already permitted a patched version, so nothing needed a range widened and no breaking upgrade was required.

The 5 code-scanning alerts are not source-code (SAST) findings — they are Trivy's filesystem scan of `package-lock.json`, i.e. the same dependency CVEs Dependabot reports. All 14 historical SnykCode `javascript/DOMXSS` alerts are already `fixed` (9) or `dismissed` (5); **no open SAST alerts exist**.

### Patched

| Package | Change | Advisory | Scope |
|---|---|---|---|
| postcss | 8.5.15 → 8.5.26 | GHSA-r28c-9q8g-f849 (high, path traversal via `sourceMappingURL`), CVE-2026-69153 | runtime |
| nanoid | 3.3.12 → 3.3.18 | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 (high, infinite loop) | runtime |
| dompurify | 3.4.12 → 3.4.13 | GHSA-55q2-fjhq-7xh7 | runtime |
| js-yaml | 4.3.0 → 4.3.1 | GHSA-5p4m-2wfm-xmqj (high) | dev |
| undici (under cheerio) | 6.27.0 → 6.28.0 | CVE-2026-15157 / 16728 / 16729 | dev |
| ip-address | 10.2.0 → 10.5.0 | CVE-2026-69192 / 69198 / 54272 | dev |
| brace-expansion | 1.1.16→1.1.18, 5.0.7→5.0.9 | ReDoS | dev |

**Actual exposure of the DOMPurify alert: none.** GHSA-55q2-fjhq-7xh7 requires `IN_PLACE: true` **plus** a hook that removes a containing element. This codebase uses neither — every `sanitize()` call in `src/lib/security-utils.ts` passes only `ALLOWED_TAGS`/`ALLOWED_ATTR`, and there is no `addHook`/`setConfig`/`IN_PLACE` anywhere in `src/`. Patched regardless, for defense in depth.

### Manifest change

`postcss` floor raised to `^8.5.23` in both `devDependencies` and `overrides`, so the vulnerable range is excluded by the manifest rather than only by the lockfile — the same pattern as the existing `sharp: ^0.35.3` CVE override.

Transitive-only packages were deliberately left **override-free**: their parents already resolve patched versions, so pinning them would add maintenance burden and future conflict risk for no security gain.

### Why these accumulated (systemic fix)

`config:recommended` leaves **`lockFileMaintenance` disabled**, so in-range lockfile drift is never remediated — and a direct dependency whose caret range already covers the fix (`postcss: ^8.5.10` already allowed 8.5.26) never gets a PR either. That combination is why 12 alerts piled up silently.

Enabled `lockFileMaintenance` so this self-heals. `minimumReleaseAge` is set to `null` for that update type because Renovate **cannot** enforce it there (the package manager performs the resolution, so there is no per-release age to check) — mirroring the official `security:minimumReleaseAgeNpm` preset. Note `minimumReleaseAge: 7 days` was never the blocker: per Renovate docs, security updates already bypass it.

### Deliberately excluded

`npm audit fix` also pulled **next 16.2.12 → 16.3.0** plus 9 `@next/*` packages. That is **not security-required** — the root `postcss` override already forces the safe version under Next — so it was reverted to keep this a security-only change. Next 16.3.0 should land via its own Renovate PR with its own review. The final lockfile diff is 9 changed / 1 added / 1 removed, all security-scoped (plus jsdom's `undici` 8.9.0→8.10.0, an in-range patch on a line that was never vulnerable).

### Verification

Node 26 / npm 11 (preserves `@next/swc` `libc` metadata — 20 entries intact, 0 removals):

- `npm audit` → **0 vulnerabilities**
- `npm ci` reproducible from the committed lockfile
- `format:check` clean · `eslint` clean · `tsc --noEmit` clean · `vitest` **44/44** · `next build` exit 0
- `docker build` succeeds; container serves `/`, `/data-sources`, `/about/team`, `/omop-cdm` → **HTTP 200**, image reports Next 16.2.12
- `renovate.json` validated with `renovate-config-validator` → "Config validated successfully"

🤖 Generated with [Claude Code](https://claude.com/claude-code)