### PR TITLE
chore(release): 1.3.2

### DIFF
--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "precision-medicine-portal",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "precision-medicine-portal",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precision-medicine-portal",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Release 1.3.2

Bumps `next-app/package.json` (and `package-lock.json` version fields) **1.3.1 → 1.3.2**. Patch release — ships the dependency **security** remediation that landed on `main` *after* the v1.3.1 tag, so it was not in the published `1.3.1` image.

> `package-lock.json` was updated with npm 11 so the `@next/swc` `libc` metadata is preserved (repo pins Node 26); the diff in this commit is version fields only.

### Highlights since v1.3.1 (1 PR)

**Security (#286)** — clears all 17 open alerts (12 Dependabot + 5 Trivy code-scanning). `npm audit`: **8 vulnerabilities (5 high, 3 moderate) → 0**.

| Package | Change | Advisory |
|---|---|---|
| postcss | 8.5.15 → 8.5.26 | GHSA-r28c-9q8g-f849 (high, path traversal via `sourceMappingURL`), CVE-2026-69153 |
| nanoid | 3.3.12 → 3.3.18 | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 (high, infinite loop) |
| dompurify | 3.4.12 → 3.4.13 | GHSA-55q2-fjhq-7xh7 |
| js-yaml | 4.3.0 → 4.3.1 | GHSA-5p4m-2wfm-xmqj (high, dev-only) |
| undici | 6.27.0 → 6.28.0 | CVE-2026-15157 / 16728 / 16729 (dev-only) |
| ip-address | 10.2.0 → 10.5.0 | CVE-2026-69192 / 69198 / 54272 (dev-only) |
| brace-expansion | 1.1.16→1.1.18, 5.0.7→5.0.9 | ReDoS (dev-only) |

`postcss` floor raised to `^8.5.23` in `devDependencies` + `overrides` so the vulnerable range is excluded by the manifest, not just the lockfile.

**Maintenance** — enabled Renovate `lockFileMaintenance` so in-range lockfile drift self-heals rather than silently accumulating transitive CVEs.

No application features or behavior changes. Next.js remains 16.2.12.

### Release checklist (post-merge)
`publish_container_image.yml` triggers on a `v*.*.*` tag push and **verifies the tag equals `package.json` version**, so:
1. Merge this PR.
2. Tag the merge commit `v1.3.2` and push it → builds & publishes the container image (+ Trivy scan).
3. Create the GitHub Release **"Version 1.3.2"** for `v1.3.2`.

### Verification
`npm audit` **0 vulnerabilities** · `format:check` clean · `eslint` clean · `tsc --noEmit` clean · `vitest` 44/44 · `next build` exit 0 · `libc` metadata intact (20 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)