### PR TITLE
Update Quality Registries

### DIFF
--- a/next-app/src/app/data-sources/quality-registries/page.tsx
+++ b/next-app/src/app/data-sources/quality-registries/page.tsx
@@ -398,7 +398,7 @@ export default function QualityRegistryPage() {
         </section>
       </div>
 
-      <LastUpdated date="16-09-2025" />
+      <LastUpdated date="11-08-2026" />
     </div>
   );
 }

--- a/next-app/src/app/data-sources/swedish-research-cohorts/page.tsx
+++ b/next-app/src/app/data-sources/swedish-research-cohorts/page.tsx
@@ -402,10 +402,9 @@ export default function SwedishResearchCohortsPage(): ReactElement {
                       {item.SND && (
                         <MetadataLink
                           href={item.SND}
-                          ariaLabel={`View SND metadata for ${item.title} (opens in new tab)`}
-                        >
-                          SND Metadata
-                        </MetadataLink>
+                          source="SND"
+                          resourceName={item.title}
+                        />
                       )}
                       <div
                         className="flex flex-wrap gap-2"

--- a/next-app/src/app/data-sources/swedish-research-cohorts/page.tsx
+++ b/next-app/src/app/data-sources/swedish-research-cohorts/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Users, Dna, Activity } from "lucide-react";
 import { sanitizeURL } from "@/lib/security-utils";
+import { MetadataLink } from "@/components/common/MetadataLink";
 import { useDebounce } from "@/hooks/useDebounce";
 
 type StudyType =
@@ -70,7 +71,6 @@ const FILTER_OPTIONS = {
 } as const;
 
 const TAG_COLOURS: { [key: string]: string } = {
-  snd: "bg-[#649ED2] text-black",
   tag: "bg-muted text-muted-foreground",
 };
 
@@ -376,8 +376,8 @@ export default function SwedishResearchCohortsPage(): ReactElement {
                     <CardTitle className="text-lg font-medium text-primary hover:underline">
                       {/*
                         Snyk Code javascript/DOMXSS on this href is a false
-                        positive. `item.link` (and `item.SND` below) come from a
-                        static, repo-committed JSON asset imported at build time —
+                        positive. `item.link` comes from a static,
+                        repo-committed JSON asset imported at build time —
                         not a user-, URL-, or network-controlled source — and
                         sanitizeURL() enforces an http/https allowlist, collapsing
                         javascript:/data:/etc. to "#" (unit-tested in
@@ -400,26 +400,12 @@ export default function SwedishResearchCohortsPage(): ReactElement {
                     </p>
                     <div className="flex flex-col gap-3">
                       {item.SND && (
-                        <a
-                          href={sanitizeURL(item.SND)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={`inline-flex items-center gap-2 px-3 py-1 text-sm font-medium rounded-full text-black ${TAG_COLOURS.snd} hover:opacity-90 self-start transition-opacity duration-100 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2`}
-                          aria-label={`View SND metadata for ${item.title} (opens in new tab)`}
+                        <MetadataLink
+                          href={item.SND}
+                          ariaLabel={`View SND metadata for ${item.title} (opens in new tab)`}
                         >
                           SND Metadata
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="20"
-                            height="20.092"
-                            className="shrink-0"
-                            aria-hidden="true"
-                            role="presentation"
-                          >
-                            <path d="m12 0 2.561 2.537-6.975 6.976 2.828 2.828 6.988-6.988L20 7.927 19.998 0H12z" />
-                            <path d="M9 4.092v-2H0v18h18v-9h-2v7H2v-14h7z" />
-                          </svg>
-                        </a>
+                        </MetadataLink>
                       )}
                       <div
                         className="flex flex-wrap gap-2"

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -42,6 +42,11 @@
   --color-error-foreground: #ffffff;
 
   --color-base-100: #f8fafc;
+
+  /* External metadata/catalogue link badge (SND, SKR, RCC). Contrast against
+     the black foreground is 7.3:1, clearing WCAG AA for normal text. */
+  --color-metadata: #649ed2;
+  --color-metadata-foreground: #000000;
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));

--- a/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
+++ b/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
@@ -1,2830 +1,2811 @@
 [
-    {
-        "name": "Barnobesitasregister i Sverige – BORIS",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "http://www.e-boris.se/",
-        "search_tags": [
-            "BORIS",
-            "childhood obesity",
-            "Sverige",
-            "obesity"
-        ],
-        "Information": "BORIS is one of the world's largest and oldest registries for the treatment of childhood obesity. It supports quality improvement and research by collecting data on treatment and outcomes in paediatric obesity care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2005",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/barnobesitasregistretisverigeboris.77541.html"
-    },
-    {
-        "name": "Endovaskulär behandling av Stroke – EVAS-registret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "http://www.evas-registret.se/",
-        "search_tags": [
-            "stroke",
-            "endovascular",
-            "stroke",
-            "Endovaskulär"
-        ],
-        "Information": "EVAS is, a government funded national quality registry in Sweden for endovascular stroke treatment with full transparency in every aspect. It is based on a modern, top-of-the-line data platform and works in close relationship and shares data with RIKS-STROKE, which is the equivalent for all stroke patients in the country.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2012",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/endovaskularbehandlingavstrokeevasregistret.77562.html"
-    },
-    {
-        "name": "Graviditetsregistret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.medscinet.com/gr/default.aspx",
-        "search_tags": [
-            "Graviditetsregistret",
-            "baby",
-            "prenatal",
-            "postnatal",
-            "fetal",
-            "neonatal"
-        ],
-        "Information": "The Pregnancy Register provides a national foundation of data for maternal and perinatal healthcare. It collects information from maternal healthcare, fetal diagnostics and delivery records to support quality improvement, follow-up and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/graviditetsregistret.77568.html"
-    },
-    {
-        "name": "InfCareHIV",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://infcarehiv.se/",
-        "search_tags": [
-            "HIV",
-            "InfCareHIV",
-            "immune",
-            "virus"
-        ],
-        "Information": "InfCareHIV is a national quality registry that collects longitudinal clinical, laboratory and treatment data for people living with HIV in Sweden. It supports clinical follow-up, quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1983",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehiv.77574.html"
-    },
-    {
-        "name": "InfCareHepatit",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.infcarehepatit.se/",
-        "search_tags": [
-            "liver",
-            "hepatitis",
-            "virus",
-            "InfCareHepatit"
-        ],
-        "Information": "InfCareHepatit is a national quality registry for hepatitis B and C in Sweden. It collects longitudinal clinical, laboratory and treatment data to support quality improvement, follow-up and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehepatit.77573.html"
-    },
-    {
-        "name": "Kvalitetsregister för cystisk fibros – CF-registret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://cf-registret.se/",
-        "search_tags": [
-            "lungs",
-            "cystic fibrosis",
-            "CF-registret"
-        ],
-        "Information": "The aim is to enhance the quality of care, survival rates, and quality of life for all cystic fibrosis (CF) patients in Sweden. It was established as a national quality registry in 2012. Since its inception, the purpose of the registry has been to continuously monitor all individuals with CF over time and ensure equitable and fair care throughout Sweden. The registry is utilised by the four CF centres in Sweden as well as some regional hospitals that treat CF patients.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2012",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterforcystiskfibroscfregistret.77556.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för assisterad befruktning – Q-IVF",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.medscinet.com/qivf/",
-        "search_tags": [
-            "reproduction",
-            "assisted reproduction",
-            "medscinet"
-        ],
-        "Information": "This registry is jointly managed by all IVF clinics in Sweden. The purpose of the registry is to continuously monitor treatment outcomes and any medical risks for both IVF children and the treated couples or women. It also provides participating clinics with data to support their development and quality improvement efforts.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2007",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforassisteradbefruktningqivf.77538.html"
-    },
-    {
-        "name": "Svenska hemofiliregistret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://svenskahemofiliregistret.se/",
-        "search_tags": [
-            "hemophilia",
-            "bleeding",
-            "blood",
-            "hemofiliregistret"
-        ],
-        "Information": "Aims to effectively monitor this specific group of patients who often receive lifelong treatment, with the goal of enhancing the quality of care. Key metrics for assessing the effectiveness of the treatment include the annual number of bleeding episodes and joint damage. Joint damage is a long-term consequence of past joint bleeding and is evaluated through functional assessments using joint scores.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2015",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaregistretforblodningssjukdomar.77548.html"
-    },
-    {
-        "name": "Svenska Intensivvårdsregistret – SIR",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.icuregswe.org/",
-        "search_tags": [
-            "SIR",
-            "Intensivvårdsregistret",
-            "intensive care",
-            "Svenska"
-        ],
-        "Information": "SIR aims to monitor and improve the quality of intensive care in Sweden within selected areas that are continuously tracked. Additionally, SIR aims to support the development of methods and research in intensive care, particularly in the field of epidemiology, as well as in other specific areas where collaboration among multiple centers is essential for conducting high-quality scientific studies.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaintensivvardsregistretsir.77587.html"
-    },
-    {
-        "name": "Svenska korsbandsregistret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.aclregister.nu/",
-        "search_tags": [
-            "ACL",
-            "korsbandsregistret"
-        ],
-        "Information": "This registry collects data on anterior cruciate ligament injuries and treatments across Sweden. Its purpose is to improve patient care by tracking surgical techniques, outcomes, and rehabilitation, as well as supporting research and benchmarking clinical practices.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2005-05-01",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskkorsbandsregister.77591.html"
-    },
-    {
-        "name": "Svenska neuroregister",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.neuroreg.se/",
-        "search_tags": [
-            "neuroregister",
-            "nervous system",
-            "neurological treatments",
-            "Svenska"
-        ],
-        "Information": "The Swedish Neuro Register gathers data on patients with neurological diseases such as multiple sclerosis, Parkinson's disease, epilepsy, and neuromuscular disorders. It aims to enhance the quality of care by monitoring treatment outcomes and supporting research into these conditions.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2001",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaneuroregister.77606.html"
-    },
-    {
-        "name": "Svensk Reumatologis Kvalitetsregister – SRQ",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "http://srq.nu/",
-        "search_tags": [
-            "arthritis",
-            "rheumatic disease",
-            "SRQ"
-        ],
-        "Information": "This registry focuses on patients with rheumatic diseases like rheumatoid arthritis and ankylosing spondylitis. It collects data on disease activity, treatments, and patient outcomes to improve care quality and facilitate research into better management strategies.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1995",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskreumatologiskvalitetsregistersrq.77620.html"
-    },
-    {
-        "name": "Svenskt neonatalt kvalitetsregister – SNQ",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://www.medscinet.com/pnq/",
-        "search_tags": [
-            "newborn",
-            "neonatal care",
-            "neonatalt",
-            "SNQ"
-        ],
-        "Information": "The SNQ collects extensive data on all newborns admitted to neonatal intensive care units (NICUs) in Sweden. This includes demographic information, birth details, diagnoses, treatments, complications, and outcomes. The data covers a wide range of neonatal conditions and interventions, such as respiratory support, infections, congenital anomalies, and more..",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2001",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktneonataltkvalitetsregistersnq.77605.html"
-    },
-    {
-        "name": "InfCare Sprututbyte",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://qrcstockholm.se/kvalitetsregister/anslutna-register",
-        "search_tags": [
-            "Sprututbyte",
-            "needle exchange",
-            "harm reduction",
-            "InfCare"
-        ],
-        "Information": "This registry is part of the InfCare system and collects data on individuals participating in needle exchange programs. This includes demographic details, health status, risk behaviours, and testing for infectious diseases like HIV and hepatitis. The registry also tracks the provision of services such as counselling, vaccinations, and referrals to healthcare or social services.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2016",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt register för levertransplantation",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "http://www.swepharm.se/",
-        "search_tags": [
-            "liver transplant",
-            "levertransplantatation"
-        ],
-        "Information": "This registry collects detailed information on all liver transplant procedures performed in Sweden, including data on donor and recipient characteristics, surgical techniques, post-transplant complications, immunosuppression protocols, and long-term follow-up outcomes such as graft survival and patient survival.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "1998",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Lungfibrosregistret",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "http://slmf.se/kvalitetsregister/lungfibrosregistret/",
-        "search_tags": [
-            "fibrosis",
-            "Lungfibrosregistret",
-            "lung",
-            "pulmonary"
-        ],
-        "Information": "The register collects data on patients diagnosed with pulmonary fibrosis, including patient demographics, diagnostic criteria, disease severity, treatment regimens, pulmonary function tests, and patient-reported outcomes. It also tracks disease progression and responses to different therapies over time. It aims to include data from all healthcare providers treating patients with pulmonary fibrosis in Sweden, covering both university hospitals and regional clinics. ",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2014",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Svenskt kvalitetsregister för atopiskt dermatit – SwedAD",
-        "registry_centre": [
-            "Kvalitetsregistercentrum Stockholm"
-        ],
-        "url": "https://swedad.nu/",
-        "search_tags": [
-            "skin",
-            "SwedAD",
-            "eczema",
-            "atopic dermatitis"
-        ],
-        "Information": "SwedAD is a national quality registry for atopic dermatitis. It supports follow-up of disease severity, treatment and patient-reported outcomes and is used for quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2019",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Amputations- och Protesregistret Swedeamp",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.swedeamp.com/",
-        "search_tags": [
-            "amputation",
-            "swedeamp",
-            "prosthetic",
-            "limb"
-        ],
-        "Information": "SwedeAmp collects information on patients undergoing amputations and those fitted with prosthetics. This includes details on the type of amputation, surgical techniques, prosthetic fittings, complications, and rehabilitation outcomes. The registry also tracks patient-reported outcomes related to mobility, function, and quality of life. The registry includes data from all healthcare providers in Sweden that perform amputations and provide prosthetic services, ensuring nationwide coverage",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/amputationsochprotesregisterswedeamp.77535.html"
-    },
-    {
-        "name": "Barnkataraktregistret PECARE",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/pecare",
-        "search_tags": [
-            "paediatric",
-            "PECARE",
-            "eye",
-            "cataract"
-        ],
-        "Information": "PECARE focuses on children with cataracts, collecting data on diagnosis, surgical treatments, visual outcomes, and follow-up care. It also tracks complications and the use of visual aids post-surgery. The registry aims to improve understanding and management of paediatric cataracts in Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2006",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "BPSD – Svenskt register för Beteendemässiga och Psykiska Symptom vid Demens",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.bpsd.se/",
-        "search_tags": [
-            "BPSD",
-            "dementia",
-            "psychological",
-            "demens"
-        ],
-        "Information": "The BPSD register collects data on individuals with dementia who exhibit behavioural and psychological symptoms. It includes information on symptom types and severity, pharmacological and non-pharmacological treatments, and care plans. The registry aims to improve the management of dementia-related symptoms and enhance patient care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforbeteendemassigaochpsykiskasymtomviddemenssjukdombpsd.77557.html"
-    },
-    {
-        "name": "CPUP – Uppföljningsprogram för Cerebral Pares",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://cpup.se/",
-        "search_tags": [
-            "treatment",
-            "palsy",
-            "cerebral palsy",
-            "cpup"
-        ],
-        "Information": "CPUP collects comprehensive data on individuals with cerebral palsy, including demographic information, motor function, associated conditions, interventions, and outcomes. It tracks long-term development and care needs, with an emphasis on preventing complications and improving quality of life. The program covers all children and adults with cerebral palsy in Sweden who receive specialised care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/cerebralparesuppfoljningsprogramcpup.77555.html"
-    },
-    {
-        "name": "HAKIR – Handkirurgiskt kvalitetsregister",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://hakir.se/",
-        "search_tags": [
-            "hand",
-            "HAKIR",
-            "surgery",
-            "reconstruction"
-        ],
-        "Information": "HAKIR gathers data on patients undergoing hand surgery, including surgical details, complications, rehabilitation processes, and functional outcomes. It also collects patient-reported outcomes related to hand function and quality of life, which are crucial for assessing the success of various surgical procedures.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/handkirurgisktkvalitetsregisterhakir.77572.html"
-    },
-    {
-        "name": "Könsdysforiregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/konsdysforiregistret",
-        "search_tags": [
-            "dysphoria",
-            "gender",
-            "identity",
-            "Könsdysforiregistret"
-        ],
-        "Information": "This registry collects data on individuals undergoing assessment and treatment for gender dysphoria, including demographic information, psychological evaluations, medical and surgical treatments, and follow-up outcomes. It aims to monitor the quality of care provided to individuals with gender dysphoria and to support research in this field.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2017",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "LKG-registret – Nationellt kvalitetsregister för läpp- käk- och/eller gomspalt",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.lkg-registret.se/",
-        "search_tags": [
-            "cleft lip",
-            "lip",
-            "palate"
-        ],
-        "Information": "Contains data on patients born with cleft lip, cleft palate, or both. It includes information on diagnosis, surgical interventions, follow-up care, speech and language outcomes, dental health, and psychosocial aspects. Data on patient demographics, types of clefts, and the timing and types of surgical procedures are also gathered. It has national coverage and includes data from all specialist centres in Sweden that treat cleft lip and palate. ",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlappkakochgomspaltlkgregistret.77600.html"
-    },
-    {
-        "name": "MMCUP – Kvalitetsregister för MMC (myelomeningocele) och annan neuralrörsdefekt",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://mmcup.se/",
-        "search_tags": [
-            "MMCUP",
-            "myelomeningocele",
-            "neural tube defect"
-        ],
-        "Information": "MMCUP is a follow-up programme and quality registry for people with myelomeningocele and related conditions. It supports systematic follow-up of function, interventions, complications and outcomes across Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterformmcannanneuralrorsdefektochhydrocefalusmmcup.77622.html"
-    },
-    {
-        "name": "Nationella Kataraktregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.kataraktreg.se/",
-        "search_tags": [
-            "eye",
-            "vision",
-            "cataract"
-        ],
-        "Information": "The National Cataract Register gathers data on cataract surgery in Sweden, including patient characteristics, surgical techniques, intraocular lenses, complications and visual outcomes. It supports quality monitoring, comparison between units and research in ophthalmic surgery.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1992",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakataraktregistret.77569.html"
-    },
-    {
-        "name": "Nationella Kvalitetsregistret för Infektionssjukdomar",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.infektionsregistret.se/",
-        "search_tags": [
-            "pathogen",
-            "infectious disease",
-            "infectious",
-            "infektionsregistret"
-        ],
-        "Information": "This registry collects data on patients diagnosed with various infectious diseases, including HIV, hepatitis, and tuberculosis. Information includes demographics, diagnostics, treatments, disease progression, and outcomes, as well as data on antimicrobial resistance and healthcare-associated infections. It covers most patients with infectious diseases treated in hospitals and clinics. ",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2007",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "RIKSHÖFT",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/rikshoft/",
-        "search_tags": [
-            "RIKSHÖFT",
-            "fracture",
-            "hip",
-            "bone"
-        ],
-        "Information": "RIKSHOFT follows hip-fracture care and outcomes in Sweden to support comparison, quality improvement and research across the care pathway.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1988",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhoftfrakturrikshoft.77583.html"
-    },
-    {
-        "name": "SKaPa – Svenskt kvalitetsregister för Karies och Parodontit",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.skapareg.se/",
-        "search_tags": [
-            "Parodontit",
-            "dental caries",
-            "SKaPa",
-            "periodontitis"
-        ],
-        "Information": "SKaPa collects data on dental health, focusing on caries (tooth decay) and periodontitis (gum disease). Information includes dental examinations, treatment methods, preventive measures, and outcomes.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforkariesochparodontitskapa.77589.html"
-    },
-    {
-        "name": "SKRS – Svenskt Kvalitetsregister för Rehabilitering vid Synnedsättning",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/skrs",
-        "search_tags": [
-            "Synnedsättning",
-            "vision rehabilitation",
-            "eyesight"
-        ],
-        "Information": "SKRS collects data on individuals undergoing rehabilitation for visual impairment, including types of visual impairments, rehabilitation interventions, assistive devices used, and functional outcomes. The register includes data from all vision rehabilitation centres across Sweden, aiming for complete national coverage",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2015",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforrehabiliteringvidsynnedsattningskrs.77619.html"
-    },
-    {
-        "name": "SQRTPA – Scandinavian Quality Register for Thyroid, Parathyroid and Adrenal surgery",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://sqrtpa.se/",
-        "search_tags": [
-            "parathyroid",
-            "thyroid",
-            "Adrenal",
-            "endocrine"
-        ],
-        "Information": "Data on patients undergoing surgery on the thyroid, parathyroid, or adrenal glands. It includes patient demographics, diagnoses, surgical details, pathology results, complications, and long-term outcomes. The registry includes data from major hospitals and surgical centres in Sweden, as well as in other Scandinavian countries.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2004",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianqualityregisterforthyroidparathyroidandadrenalsurgerysqrtpa.77561.html"
-    },
-    {
-        "name": "Svenska Cornearegistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/cornea",
-        "search_tags": [
-            "transplant",
-            "corneal",
-            "Cornearegistret",
-            "vision"
-        ],
-        "Information": "Collects data on corneal surgeries, including corneal transplants. It tracks patient demographics, surgical techniques, donor and recipient details, complications, and visual outcomes. The registry includes data from all ophthalmology departments performing corneal surgeries in Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1996",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskacornearegistret.77579.html"
-    },
-    {
-        "name": "Svenska Nationella Fotledsregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.swedankle.se/",
-        "search_tags": [
-            "orthopedics",
-            "surgery",
-            "ankle",
-            "ankle surgery"
-        ],
-        "Information": "Data on ankle surgeries, including fracture types, surgical techniques, complications, rehabilitation, and functional outcomes such as mobility and pain.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1997",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskanationellafotledsregistret.77563.html"
-    },
-    {
-        "name": "Svenska Makularegistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://makulareg.se/",
-        "search_tags": [
-            "macular",
-            "eye",
-            "retina",
-            "macular diseases"
-        ],
-        "Information": "The registry gathers data on patients with macular diseases, such as age-related macular degeneration (AMD). It includes information on diagnosis, treatments (especially anti-VEGF injections), visual outcomes, and patient-reported outcomes. Includes data from all ophthalmology clinics treating macular diseases in Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskamakularegistret.77601.html"
-    },
-    {
-        "name": "Svenska Skulder- och Armbågsregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/ssar",
-        "search_tags": [
-            "shoulder and elbow",
-            "Armbågsregistret",
-            "shoulder"
-        ],
-        "Information": "Data on shoulder and elbow surgeries, including patient demographics, diagnoses, surgical procedures, rehabilitation, complications, and outcomes such as range of motion and pain.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1999",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaskulderocharmbagsregistret.77624.html"
-    },
-    {
-        "name": "SweTrau – Svenska Traumaregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "http://www.swetrau.se/",
-        "search_tags": [
-            "SweTrau",
-            "Traumaregistret",
-            "trauma",
-            "injury"
-        ],
-        "Information": "SweTrau collects data on trauma patients, including types of injuries, severity, treatments provided, and outcomes such as survival rates and functional recovery. The registry includes data from all major trauma centres and emergency departments in Sweden, ensuring comprehensive national coverage of trauma care and outcomes.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskatraumaregistret.77632.html"
-    },
-    {
-        "name": "AmbuReg – Ambulansregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/ambureg/",
-        "search_tags": [
-            "paramedic",
-            "AmbuReg",
-            "ambulance",
-            "emergency"
-        ],
-        "Information": "AmbuReg is the national quality registry for ambulance care in Sweden. It supports quality improvement, follow-up and comparison of prehospital emergency care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2016",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Analfistelregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "Analfistelregistret",
-            "colorectal",
-            "anal",
-            "fistula"
-        ],
-        "Information": "This registry collects information on patients undergoing treatment for anal fistulas, including demographic data, types of fistulas, surgical and non-surgical treatments, complications, and outcomes such as healing rates and recurrence.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "GamReg Sweden – Kvalitetsregister för spel- och dataspelsberoende",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register/gamreg-sweden",
-        "search_tags": [
-            "gamreg",
-            "addiction",
-            "gambling addiction",
-            "gaming addiction"
-        ],
-        "Information": "GamReg collects data on individuals seeking treatment for gambling and gaming addiction. This includes information on demographics, types of addiction, treatments provided (such as counselling or medication), and outcomes related to addiction severity and recovery. The registry covers multiple treatment centres and clinics across Sweden that specialise in addiction therapy.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2019",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Glaukomregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "optic nerve",
-            "glaucoma",
-            "vision",
-            "Glaukomregistret"
-        ],
-        "Information": "The Glaucoma Register collects data on patients diagnosed with glaucoma, including patient demographics, diagnostic criteria, intraocular pressure measurements, visual field data, treatments (medications or surgeries), and outcomes.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "LHON-registret – Registret för Lebers Hereditära Opticusneuropati",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://lhon-registret.se/",
-        "search_tags": [
-            "optic",
-            "Lebers",
-            "Leber's hereditary optic neuropathy",
-            "LHON-registret"
-        ],
-        "Information": "The Swedish LHON Registry is currently a research registry for Leber hereditary optic neuropathy (LHON). Its primary purpose is to facilitate research projects and improve knowledge about the condition.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2018",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "LSR – Lund Stroke Register",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://portal.research.lu.se/sv/projects/lund-stroke-register",
-        "search_tags": [
-            "endovascular",
-            "Register",
-            "stroke",
-            "LSR"
-        ],
-        "Information": "The Lund Stroke Register collects data on patients admitted to the Lund University Hospital with a diagnosis of stroke. Data includes patient demographics, stroke type and severity, treatments provided, rehabilitation, and outcomes. The registry specifically covers patients treated at Lund University Hospital, providing detailed insights into stroke care and outcomes within this institution.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2001",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Njurtransplantationsregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "Njurtransplantationsregistret",
-            "renal",
-            "transplant",
-            "kidney"
-        ],
-        "Information": "Collects data on kidney transplant procedures and outcomes.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Barnkirurgi operationsregister",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "paediatric surgeries",
-            "Barnkirurgi"
-        ],
-        "Information": "Monitors outcomes of paediatric surgeries.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Register för brachyterapi vid uvealt melanom",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "melanoma",
-            "brachytherapy",
-            "Register",
-            "uveal melanoma"
-        ],
-        "Information": "Tracks outcomes of brachytherapy for uveal melanoma.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Sklerodermiregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "skin",
-            "autoimmune",
-            "Sklerodermiregistret",
-            "scleroderma"
-        ],
-        "Information": "Monitors treatment outcomes for scleroderma patients.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Svenska Lambåregistret",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "Svenska",
-            "Lambåregistret"
-        ],
-        "Information": "Tracks outcomes of flap surgeries and patient recovery.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "SweAAA – Svenskt Register för Abdominellt Aortaaneurysm",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://rcsyd.se/anslutna-register",
-        "search_tags": [
-            "aortic",
-            "abdominal aortic aneurysm",
-            "vascular"
-        ],
-        "Information": "Monitors outcomes of abdominal aortic aneurysm treatments.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "RaraSwed – Nationellt kvalitetsregister för sällsynta hälsotillstånd",
-        "registry_centre": [
-            "Registercentrum Syd"
-        ],
-        "url": "https://sodrasjukvardsregionen.se/csd-syd/raraswed-kvalitetsregister/",
-        "search_tags": [
-            "RaraSwed",
-            "rare disease",
-            "genetic",
-            "Sällsynta diagnoser",
-            "sällsynta hälsotillstånd"
-        ],
-        "Information": "RaraSwed is the Swedish national quality registry for rare health conditions. It collects structured information across rare diagnoses to support quality improvement, follow-up and research and to improve knowledge about healthcare and outcomes for people living with rare conditions.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "Unknown",
-        "verification_source": "Official registry source",
-        "verification_url": "https://rcsyd.se/anslutna-register/raraswed-nationellt-kvalitetsregister-for-sallsynta-diagnoser",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "PsoReg – Nationellt register för systembehandling av psoriasis",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://psoreg.se/",
-        "search_tags": [
-            "skin",
-            "psoriasis",
-            "PsoReg",
-            "psoriasis treatment"
-        ],
-        "Information": "PsoReg tracks patients undergoing systemic treatment for psoriasis, collecting data on treatment efficacy, patient demographics, disease severity, and quality of life. It covers dermatology clinics across Sweden, aiming for nationwide coverage to monitor long-term outcomes and improve patient care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2006",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registerforsystembehandlingavpsoriasispsoreg.77616.html"
-    },
-    {
-        "name": "Riksstroke – Nationellt kvalitetsregister för strokesjukvård",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://www.riksstroke.org/sve/",
-        "search_tags": [
-            "Riksstroke",
-            "endovascular",
-            "stroke",
-            "kvalitetsregister"
-        ],
-        "Information": "Riksstroke gathers data on stroke care, including patient characteristics, acute treatment, rehabilitation, and long-term follow-up. It covers all hospitals in Sweden, ensuring comprehensive national coverage, and provides insights into stroke outcomes and healthcare quality improvements.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1994",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakvalitetsregistretforstrokeriksstroke.77627.html"
-    },
-    {
-        "name": "Svenskt Bråckregister  – Nationellt kvalitetsregister inom bråckkirurgi",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "http://svensktbrackregister.se/",
-        "search_tags": [
-            "bråck"
-        ],
-        "Information": "This register collects information on hernia surgeries, including patient demographics, surgical techniques, complications, and outcomes such as recurrence rates. It covers hospitals and clinics performing hernia surgeries in Sweden, providing comprehensive national data on treatment quality.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1992",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktbrackregister.77598.html"
-    },
-    {
-        "name": "GynOp – Nationella kvalitetsregister inom gynekologisk kirurgi",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://www.gynop.se/",
-        "search_tags": [
-            "gynecological surgeries",
-            "GynOp",
-            "gynecological"
-        ],
-        "Information": "Tracks outcomes of gynaecological surgeries, collecting data on patient demographics, surgical methods, complications, and recovery. It covers nearly all hospitals in Sweden performing gynaecological surgeries, offering extensive national coverage to improve surgical outcomes and patient safety. The register includes the following subregisters: Intrauterin kirurgi; Rekonstruktiv bäckenbottenkirurgi; Inkontinens; Bristning; Hysterektomi, adnex- och endometrioskirurgi",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterinomgynekologiskkirurgigynop.77570.html"
-    },
-    {
-        "name": "SveATTR – Svenska transtyretinamyloidosregistret",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://regionvasterbotten.se/for-vardgivare/kunskapsstod/kvalitetsregistret-sveattr",
-        "search_tags": [
-            "transtyretinamyloidosregistret",
-            "SveATTR"
-        ],
-        "Information": "SveATTR collects data on patients with transthyretin amyloidosis and genetic carriers. It tracks patient demographics, treatments, and outcomes to improve care and facilitate research. It includes data from hospitals across Sweden,",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2019",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "DBS – Kvalitetsregister inom deep brain stimulation",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://rcnorr.se/anslutna-register/",
-        "search_tags": [
-            "DBS",
-            "stimulation",
-            "deep brain"
-        ],
-        "Information": "The registry tracks patients undergoing deep brain stimulation (DBS) for movement disorders. It collects data on surgical procedures, outcomes, and complications. Coverage includes hospitals performing DBS in Sweden​,",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "CKG – Kardiovaskulär genetik",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://www.regionvasterbotten.se/forskning/profilomraden/kardiovaskular-genetik",
-        "search_tags": [
-            "Kardiovaskulär",
-            "genetik",
-            "CKG",
-            "Cardiovascular"
-        ],
-        "Information": "This registry collects data on patients with genetic cardiovascular conditions, focusing on genetic information, treatments, and patient outcomes. It aims for national coverage​.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "Unknown",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Terapeutisk aferes – Internationellt register för terapeutisk aferes behandling",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://www.waa-registry.org/",
-        "search_tags": [
-            "aferes"
-        ],
-        "Information": "This international registry gathers data on therapeutic apheresis treatments, tracking patient demographics, procedures, and outcomes to improve treatment protocols across participating countries​.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "1992",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "AURICULA – Nationellt register för förmaksflimmer och antikoagulation",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/auricula/",
-        "search_tags": [
-            "atrial fibrillation",
-            "aFib"
-        ],
-        "Information": "This registry collects data on patients with atrial fibrillation, focusing on diagnostic procedures, treatments, and outcomes to improve care for those requiring anticoagulation. It covers hospitals and clinics across Sweden​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2007",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "GallRiks – Svenskt kvalitetsregister för gallstenskirurgi",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/gallriks/",
-        "search_tags": [
-            "GallRiks",
-            "cholecystectomy",
-            "gallstone surgery"
-        ],
-        "Information": "GallRiks is Sweden's national quality registry for gallstone surgery and ERCP. It records gallbladder surgery, ERCP procedures and postoperative complications and supports quality monitoring, comparison between units and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2005",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforgallstenskirurgiochercpgallriks.77567.html"
-    },
-    {
-        "name": "Kateterablationsregistret – Nationellt kvalitetsregister för kateterablation vid hjärtrusningar",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "http://www.ablationsregistret.se/",
-        "search_tags": [
-            "kateterablation",
-            "cardiovascular"
-        ],
-        "Information": "This registry collects data on catheter ablation for arrhythmias, including procedural details and patient outcomes. It covers Swedish hospitals performing these procedures​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2004",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkateterablation.77544.html"
-    },
-    {
-        "name": "NRS – Nationellt register över smärtrehabilitering",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/nrs/",
-        "search_tags": [
-            "pain",
-            "pain rehab"
-        ],
-        "Information": "NRS gathers data on patients undergoing pain rehabilitation for chronic pain. It collects information on treatments, rehabilitation plans, and patient-reported outcomes to monitor and improve the quality of life for these patients. NRS covers clinics across Sweden and is aimed at both short- and long-term outcome analysis​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisteroversmartrehabiliteringnrs.77626.html"
-    },
-    {
-        "name": "RiksSvikt – Nationellt kvalitetsregister för hjärtsvikt",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/rikssvikt/",
-        "search_tags": [
-            "RiksSvikt",
-            "hear disease"
-        ],
-        "Information": "RiksSvikt is a national quality registry for heart failure. It collects data on diagnostics, treatment and long-term outcomes to support guideline-based care, quality improvement and research across Swedish hospitals.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2003",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellthjartsviktsregisterrikssvikt.77578.html"
-    },
-    {
-        "name": "RiksSår – Nationellt kvalitetsregister för svårläkta sår",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.rikssar.se/",
-        "search_tags": [
-            "svårläkta",
-            "RiksSår",
-            "wound"
-        ],
-        "Information": "This registry gathers data on patients with chronic wounds, focusing on wound types, treatments, and healing outcomes. It aims to improve care for patients with non-healing wounds and involves both primary and specialist care facilities across Sweden​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforpatientermedsvarlaktasarrikssar.77628.html"
-    },
-    {
-        "name": "Senior alert – Nationellt kvalitetsregister för vård och omsorg",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.senioralert.se/",
-        "search_tags": [
-            "Senior",
-            "senior alert",
-            "treatment"
-        ],
-        "Information": "Senior alert is a national quality registry and a tool for preventive care. It supports systematic prevention and follow-up of risks including falls, pressure ulcers, malnutrition, poor oral health and bladder dysfunction.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforvardochomsorgsenioralert.77634.html"
-    },
-    {
-        "name": "SOReg – Scandinavian Obesity Surgery Registry",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.soreg.se/",
-        "search_tags": [
-            "Obesity",
-            "Scandinavian",
-            "Surgery",
-            "SOReg"
-        ],
-        "Information": "SOReg is a quality registry for bariatric surgery. It follows procedures, complications, weight outcomes and long-term follow-up and supports quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2007",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianobesitysurgeryregistersoreg.77611.html"
-    },
-    {
-        "name": "SPAHR – Svenska PAH och CTEPH-registret",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/spahr/",
-        "search_tags": [
-            "registret",
-            "CTEPH",
-            "SPAHR"
-        ],
-        "Information": "SPAHR is a national quality registry for pulmonary arterial hypertension (PAH) and chronic thromboembolic pulmonary hypertension (CTEPH). It follows diagnosis, treatment, function, quality of life and prognosis and supports national comparison, quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapahochctephregistretspahr.77584.html"
-    },
-    {
-        "name": "SPOR – Svenskt perioperativt register",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://spor.se/",
-        "search_tags": [
-            "register",
-            "SPOR",
-            "UCR",
-            "perioperativt"
-        ],
-        "Information": "SPOR is a national quality registry that collects perioperative data for patients undergoing surgery. It supports patient safety, quality improvement, national comparison and research across perioperative care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktperioperativtregisterspor.77610.html"
-    },
-    {
-        "name": "SveDem – Svenska registret för kognitiva sjukdomar/demenssjukdomar",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/svedem/",
-        "search_tags": [
-            "Cognitive",
-            "Dementia",
-            "UCR",
-            "SveDem"
-        ],
-        "Information": "SveDem, the Swedish Registry for Cognitive/Dementia Disorders, supports systematic follow-up of diagnosis, treatment, care and support for people with cognitive disorders. It is used for quality improvement, national follow-up and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2007",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforkognitivasjukdomardemenssjukdomarsvedem.77558.html"
-    },
-    {
-        "name": "SWEDCON – Barnhjärtregistret (inkluderar GUCH, det vill säga vuxna med medfött hjärtfel)",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/swedcon/",
-        "search_tags": [
-            "GUCH",
-            "children",
-            "heart",
-            "SWEDCON"
-        ],
-        "Information": "SWEDCON focuses on congenital heart disease, tracking surgeries, treatments, and outcomes for children and adults with congenital heart defects. It includes all centres in Sweden treating congenital heart disease, ensuring comprehensive national coverage​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1998",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterformedfoddahjartsjukdomarswedcon.77603.html"
-    },
-    {
-        "name": "SWEDEHEART – Sammanslagning av RIKS-HIA, SEPHIA, SCAAR, TAVI, Svenska Hjärtkirurgiregistret och Kardiogenetikregistret.",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/swedeheart/",
-        "search_tags": [
-            "SEPHIA",
-            "SCAAR",
-            "TAVI",
-            "SwEDEHEART"
-        ],
-        "Information": "SWEDEHEART is a national registry that includes data from acute coronary care (RIKS-HIA), coronary angiography (SCAAR), heart surgery, and secondary prevention (SEPHIA). It covers nearly all cardiac care units in Sweden, providing comprehensive data on heart disease management",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforhjartintensivvardkranskarlsrontgenpcihjartkirurgiochsekundarpreventionswedeheart.77576.html"
-    },
-    {
-        "name": "SWEDEVOX – Andningssviktregistret över oxygenbehandling och respiratorbehandling i hemmet",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/swedevox/",
-        "search_tags": [
-            "oxygen",
-            "UCR",
-            "SWEDEVOX"
-        ],
-        "Information": "This registry collects data on patients receiving oxygen or ventilator therapy for respiratory failure at home. It tracks treatment outcomes and covers hospitals providing these services across Sweden​.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/andningssviktsregistretswedevox.77536.html"
-    },
-    {
-        "name": "SWEDVASC – Nationellt register för kärlkirurgi",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/swedvasc/",
-        "search_tags": [
-            "vain",
-            "SWEDVASC"
-        ],
-        "Information": "SWEDVASC is the national quality registry for vascular surgery. It follows procedures such as aneurysm repair and treatment of peripheral artery disease and supports quality improvement, comparison and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1994",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkarlkirurgiswedvasc.77592.html"
-    },
-    {
-        "name": "SVAR – Svenskt akutvårdsregister",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/svar/",
-        "search_tags": [
-            "acute",
-            "SVAR",
-            "acute care"
-        ],
-        "Information": "SVAR is a national registry covering the emergency care pathway, including prehospital care, emergency departments and acute wards. It supports quality improvement and follow-up of emergency care across Sweden.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "TBI – Traumatic Brain Injury",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/tbi/",
-        "search_tags": [
-            "TBI",
-            "Brain",
-            "Injury",
-            "Traumatic"
-        ],
-        "Information": "The Traumatic Brain Injury registry collects data on patients with severe brain injuries, focusing on trauma mechanisms, treatments, and rehabilitation outcomes. While no specific patient numbers were found, this registry is part of broader national efforts to improve care for trauma patients across Sweden​.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "ThoR – Allmän Thoraxkirurgi",
-        "registry_centre": [
-            "Uppsala Clinical Research Center"
-        ],
-        "url": "https://www.ucr.uu.se/thor/",
-        "search_tags": [
-            "ThoR",
-            "Thorax",
-            "Thoraxkirurgi"
-        ],
-        "Information": "Collects data on surgeries involving the lungs, trachea, esophagus, pleura, pericardium, thymus, diaphragm, and the chest wall including bones and muscles. While a significant portion of the surgeries focus on lung cancer, it also includes data on surgeries for benign conditions. The registry tracks surgical outcomes and complications to improve thoracic surgery care across Sweden​.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "BRIMP – Bröstimplantatregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://brimp.registercentrum.se/",
-        "search_tags": [
-            "Breast implant",
-            "Bröstimplantatregistret",
-            "BRIMP"
-        ],
-        "Information": "BRIMP is the national breast implant registry. It collects data on cosmetic and reconstructive breast implant procedures, implant types, surgical methods and complications to support patient safety and quality improvement.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2014",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/brostimplantatregistret.77550.html"
-    },
-    {
-        "name": "Kranio – Kranioregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://kranio.registercentrum.se/",
-        "search_tags": [
-            "Kranioregistret",
-            "Kranio",
-            "cranial"
-        ],
-        "Information": "This registry collects data on patients undergoing cranial surgery for congenital malformations, trauma, or other conditions. It tracks surgical outcomes, complications, and long-term recovery but does not have widely available patient numbers. Coverage includes hospitals performing cranial surgeries across Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2023",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "LVR – Luftvägsregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://lvr.registercentrum.se/",
-        "search_tags": [
-            "Luftvägsregistret",
-            "LVR",
-            "airways"
-        ],
-        "Information": "LVR gathers data on respiratory disorders, particularly focusing on patients requiring long-term oxygen or ventilator support. The registry tracks treatment types, patient demographics, and outcomes across Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/luftvagsregistret.77590.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för öron-, näs- och halssjukvård",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://orl.registercentrum.se/",
-        "search_tags": [
-            "ear,",
-            "nose",
-            "throat",
-            "treatment"
-        ],
-        "Information": "Tracks treatments and outcomes for various ENT conditions. It includes nine sub-registries: surgery for hearing improvement with stapes prostheses, nasal septum surgery, tympanostomy tube surgeries, vocal cord surgery, hearing rehabilitation with hearing aids, cochlear implants, tonsillectomy, eardrum repair surgeries, and snoring surgeries. These registries cover hospitals and clinics across Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1997",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfororonnasochhalssjukvard.81907.html"
-    },
-    {
-        "name": "NDR – Nationella Diabetesregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://ndr.registercentrum.se/",
-        "search_tags": [
-            "NDR",
-            "Nationella",
-            "Diabetes"
-        ],
-        "Information": "The National Diabetes Register collects data on diabetes care, risk factors, treatment and outcomes. It is used for quality improvement, benchmarking, follow-up and research in Swedish diabetes care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1996",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelladiabetesregistretndr.77559.html"
-    },
-    {
-        "name": "NROK – Nationella registret för ortognatkirurgi",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://nrok.registercentrum.se/",
-        "search_tags": [
-            "orthognathic surgery",
-            "NROK"
-        ],
-        "Information": "This registry collects data on 900-1000 corrective jaw surgeries annually in Sweden. The focus is on improving care quality and ensuring equal access to treatment for patients with dentofacial anomalies. It tracks surgical outcomes and patient safety, helping to ensure consistent standards of care across clinics​",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2018",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "QregPV – Primärvårdens kvalitetsregister Västra Götaland",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://qregpv.registercentrum.se/",
-        "search_tags": [
-            "QregPV"
-        ],
-        "Information": "QregPV is a regional quality registry for primary care in Vastra Gotaland. It supports systematic follow-up and quality improvement in primary care by compiling relevant clinical indicators and outcomes.",
-        "category": [
-            "Other quality registry"
-        ],
-        "start_date": "2006",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Riksfot – Svenska fotkirurgiska registret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://fot.registercentrum.se/",
-        "search_tags": [
-            "foot",
-            "feet",
-            "Riksfot",
-            "surgery"
-        ],
-        "Information": "Riksfot is the Swedish foot surgery registry. It follows foot and ankle surgical procedures, patient characteristics and outcomes to support quality improvement, comparison between units and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafotkirurgiskaregistretriksfot.77564.html"
-    },
-    {
-        "name": "SESAR – Svenska Sömnapnéregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://sesar.registercentrum.se/",
-        "search_tags": [
-            "apnea",
-            "SESAR",
-            "sleep apnea"
-        ],
-        "Information": "SESAR is a national quality registry for sleep apnoea. It follows diagnosis, treatment and follow-up of patients with suspected or confirmed sleep apnoea, mainly obstructive sleep apnoea, and supports quality improvement and service development.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskasomnapneregistretsesar.77629.html"
-    },
-    {
-        "name": "SFR – Svenska Frakturregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://sfr.registercentrum.se/",
-        "search_tags": [
-            "SFR",
-            "fracture"
-        ],
-        "Information": "The Swedish Fracture Register follows fractures treated in Sweden, including fracture characteristics, injury mechanisms, treatment and outcomes for both surgical and non-surgical care. It supports clinical feedback, quality improvement and research in fracture care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafrakturregistret.77565.html"
-    },
-    {
-        "name": "SLR – Svenska Ledprotesregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://slr.registercentrum.se/",
-        "search_tags": [
-            "Ledprotesregistret",
-            "prothese",
-            "SLR"
-        ],
-        "Information": "This is a national quality registry that tracks all hip and knee joint replacement surgeries, including primary operations, revisions, and osteotomies (surgical bone cuts to correct alignment) performed across Sweden. The registry was officially established in 2020 after merging two previously separate registers—the Swedish Hip Arthroplasty Register (started in 1979) and the Swedish Knee Arthroplasty Register (started in 1975). Since then, SLR has been systematically collecting data to monitor and improve the quality of joint replacement surgeries nationwide​. The registry covers all units performing joint replacements in Sweden, ensuring a very high coverage rate.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2020",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaledprotesregistret.77595.html"
-    },
-    {
-        "name": "SPOQ – Svenskt Pediatriskt Ortopediskt Qvalitetsregister",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://spoq.registercentrum.se/",
-        "search_tags": [
-            "Ortopediskt",
-            "orthopedic",
-            "child",
-            "Pediatric care"
-        ],
-        "Information": "SPOQ is a national quality registry for paediatric orthopaedics. It focuses on conditions such as developmental dysplasia of the hip, Perthes disease, slipped capital femoral epiphysis, clubfoot and patellar dislocation, and supports timely diagnosis, treatment follow-up and quality improvement.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2015",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktpediatrisktortopedisktqvalitetsregisterspoq.77612.html"
-    },
-    {
-        "name": "Svenska Artrosregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://boa.registercentrum.se/",
-        "search_tags": [
-            "svenska artros",
-            "arthritis"
-        ],
-        "Information": "Svenska Artrosregistret is a national quality registry that follows first-line osteoarthritis care and patient-reported outcomes. It is used for quality improvement, service follow-up and research in osteoarthritis care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaartrosregistret.77537.html"
-    },
-    {
-        "name": "Svenska Hjärt- lungräddningsregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://shlr.registercentrum.se/",
-        "search_tags": [
-            "cardiopulmonary resuscitation"
-        ],
-        "Information": "The Swedish Registry of Cardiopulmonary Resuscitation collects data on cardiac-arrest events and the critical links in the chain of survival, both in and outside hospital. It supports quality improvement, comparison and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1990",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahjartlungraddningsregistret.77577.html"
-    },
-    {
-        "name": "Svenska Thoraxtransplantationsregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://strax.registercentrum.se/",
-        "search_tags": [
-            "Thoraxtransplantationsregistret",
-            "transplant"
-        ],
-        "Information": "The Swedish Thoracic Transplant Registry follows heart and lung transplantation, including waiting-list information, perioperative care and long-term follow-up. It supports quality monitoring and research in thoracic transplantation.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2018",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Svenskt Register för Rehabiliteringsmedicin",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://svereh.registercentrum.se/",
-        "search_tags": [
-            "rehab",
-            "rehabilitation",
-            "Rehabiliteringsmedicin",
-            "svereh"
-        ],
-        "Information": "Aimed at improving rehabilitation services for patients with brain injuries, spinal cord injuries, and other complex conditions. The registry collects data on demographics, rehabilitation outcomes, waiting times, and patient satisfaction. The registry supports continuous improvement in service quality and is widely used for research purposes.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2021",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktregisterforrehabiliteringsmedicin.77618.html"
-    },
-    {
-        "name": "SWEAPS – Svenska registret för avancerad barn- och ungdomskirurgi",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://sweaps.registercentrum.se/",
-        "search_tags": [
-            "surgery",
-            "SWEAPS"
-        ],
-        "Information": "Gathers comprehensive data on children requiring complex surgical interventions due to congenital malformations in the esophagus, intestines, and urinary system. It covers rare conditions like esophageal atresia and congenital diaphragmatic hernia. The goal is to enhance care quality, reduce risks, and improve long-term patient outcomes. Data collected includes patient demographics, surgical details, and long-term follow-ups from specialised centres.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2016",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Bipolär- och psykosregistret – Nationellt kvalitetsregister för bipolär sjukdom och schizofrenispektrumtillstånd",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://bipsy.registercentrum.se/",
-        "search_tags": [
-            "Schizophrenia",
-            "bipolar",
-            "psychosis"
-        ],
-        "Information": "The bipolar and psychosis registry is a national quality registry for bipolar disorder and schizophrenia spectrum conditions. It collects data on disease course, medication, treatment outcomes and care processes to support quality improvement and research in psychiatric care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2004",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/bipolarochpsykosregistretbipsy.77546.html"
-    },
-    {
-        "name": "Bättre Beroendevård",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://www.battreberoendevard.regionstockholm.se/",
-        "search_tags": [
-            "Beroendevård",
-            "addiction"
-        ],
-        "Information": "Focuses on patients receiving specialised care for substance use disorders, covering diagnoses such as alcohol, opioid, and multi-substance dependencies (ICD-10 codes F10-F19). Established to improve the quality and accessibility of addiction treatment, the registry tracks data on care plans, participation in medication-assisted programs (e.g., LARO for opioid addiction), and questions about the patient’s family situation, such as the presence of minors. The registry collaborates with healthcare units across Sweden, ensuring that treatment outcomes are monitored and used to refine addiction care strategies.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/battreberoendevard.77545.html"
-    },
-    {
-        "name": "Kvalitetsregister ECT",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://ect.rcnorr.se/",
-        "search_tags": [
-            "ECT",
-            "electroconvulsive therapy"
-        ],
-        "Information": "The ECT quality registry collects data on electroconvulsive therapy used mainly for severe psychiatric conditions such as depression. It also follows repetitive transcranial magnetic stimulation (rTMS) and supports quality monitoring and national comparison of these treatments.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2012",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterect.77560.html"
-    },
-    {
-        "name": "Q-bup – Nationellt kvalitetsregister för barn- och ungdomspsykiatri",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://qbup.registercentrum.se/",
-        "search_tags": [
-            "peadiatric care",
-            "child psychiatry",
-            "psychiatry"
-        ],
-        "Information": "Q-bup is the national quality registry for child and adolescent psychiatry. It collects data on demographics, diagnoses, treatments and outcomes to support quality improvement and more equal mental health services across Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2017",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Riksät – Nationellt kvalitetsregister för ätstörningsbehandling",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://riksat.registercentrum.se/",
-        "search_tags": [
-            "Riksät",
-            "psychiatry",
-            "eating disorder"
-        ],
-        "Information": "Riksat is a national quality registry for eating-disorder treatment. It collects information on care, treatment, outcomes and patient experience and supports quality improvement and longitudinal follow-up.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1999",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "RättspsyK – Nationellt rättspsykiatriskt kvalitetsregister",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://rattspsyk.registercentrum.se/",
-        "search_tags": [
-            "rättspsykiatriskt",
-            "RättspsyK",
-            "psychiatry"
-        ],
-        "Information": "RättspsyK is the national quality registry for forensic psychiatric care. It follows treatment plans, risk assessments, coercive measures, health status and related outcomes to support quality improvement and follow-up of compulsory forensic psychiatric care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltrattspsykiatrisktkvalitetsregisterrattspsyk.77623.html"
-    },
-    {
-        "name": "SibeR – Svenska internetbehandlingsregistret",
-        "registry_centre": [
-            "Registercentrum Västra Götaland"
-        ],
-        "url": "https://siber.registercentrum.se/",
-        "search_tags": [
-            "internetbehandlingsregistret",
-            "SibeR"
-        ],
-        "Information": "SibeR is a national quality registry for internet-delivered psychological treatment. It collects information on access to treatment, treatment processes, mental-health outcomes and completion and supports quality-driven development of digital care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2015",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskainternetbehandlingsregistretsiber.77588.html"
-    },
-    {
-        "name": "Barnnjurregistret (BNR)",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "http://barnnjurregistret.se/",
-        "search_tags": [
-            "Barnnjurregistret",
-            "BNR"
-        ],
-        "Information": "Collects data on children and adolescents with kidney diseases in Sweden. It aims to improve care quality and monitor long-term outcomes for these patients. The register includes data from all paediatric nephrology units across the country, covering several hundred individuals. Key variables include disease diagnosis, treatments, and progression.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1998",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnnjurregistret.77608.html"
-    },
-    {
-        "name": "Barnreumaregistret",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "http://barnreumaregistret.se/",
-        "search_tags": [
-            "Barnreumaregistret",
-            "reuma",
-            "rheumatic disease"
-        ],
-        "Information": "Collects data on children with paediatric rheumatic diseases in Sweden. Its main purpose is to monitor the progression of these diseases, treatments given, comorbidities, and the health and quality of life of patients. Data from patients are used to track short- and long-term effects of treatments, allowing healthcare providers to improve the quality of care. The register covers all relevant healthcare units in Sweden.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnreumaregistret.77594.html"
-    },
-    {
-        "name": "Registret för medfödda metabola sjukdomar (RMMS)",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "http://rmms.se/",
-        "search_tags": [
-            "born",
-            "RMMS"
-        ],
-        "Information": "RMMS follows people with inherited metabolic disorders. It collects data on demographics, diagnoses, treatments and outcomes to support standardised care, quality improvement and research in rare metabolic disease.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registretformedfoddametabolasjukdomarrmms.77604.html"
-    },
-    {
-        "name": "Svenska Barnhälsovårdsregistret (BHVQ)",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "http://bhvq.se/",
-        "search_tags": [
-            "child",
-            "BHVQ",
-            "Barnhälsovårdsregistret"
-        ],
-        "Information": "It collects comprehensive data on various health indicators for children, such as growth metrics, maternal mental health screenings, and language development assessments, across all child healthcare centres in Sweden. The registry includes variables such as vaccination status, parental support programs, and exposure to secondhand smoke, which are tracked from the child's first to final visits. BHVQ facilitates nationwide monitoring of child health services, supporting research and quality improvement initiatives.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "PIDcare",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "http://pidcare.se/",
-        "search_tags": [
-            "PIDcare"
-        ],
-        "Information": "The PIDcare registry focuses on individuals with primary immunodeficiencies (PID) and was established to improve care by tracking patient data, treatment outcomes, and long-term health. It collects detailed information on diagnosis, genetic findings, treatments, and immunological parameters.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2012",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforprimaraimmunbristerpidcare.77614.html"
-    },
-    {
-        "name": "Svenskt Njurregister (SNR)",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "https://www.snronline.se/",
-        "search_tags": [
-            "SNR",
-            "Njurregister",
-            "kidney"
-        ],
-        "Information": "Svenskt Njurregister follows chronic kidney disease, dialysis and kidney transplantation in Sweden. It supports clinical follow-up, quality improvement, benchmarking and research in kidney care.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1991",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktnjurregistersnr.77609.html"
-    },
-    {
-        "name": "Swespine – Svenska Ryggregistret",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "https://www.swespine.se/",
-        "search_tags": [
-            "Swespine",
-            "spine",
-            "spine disorders",
-            "Ryggregistret"
-        ],
-        "Information": "Swespine, the Swedish Spine Registry, follows spine surgery, patient characteristics, procedures and patient-reported outcomes. It supports quality assurance, comparison of treatment results and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "1998",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaryggregistretswespine.77621.html"
-    },
-    {
-        "name": "SWIBREG",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "https://www.swibreg.se/",
-        "search_tags": [
-            "Swibreg",
-            "SWIBREG",
-            "IBD"
-        ],
-        "Information": "SWIBREG is a national quality registry for inflammatory bowel disease. It follows treatment, disease activity, healthcare use and patient-reported outcomes and supports quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2013",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforinflammatorisktarmsjukdomswibreg.77586.html"
-    },
-    {
-        "name": "Svenska Palliativregistret",
-        "registry_centre": [
-            "Registercentrum Sydost"
-        ],
-        "url": "https://www.palliativregistret.se/",
-        "search_tags": [
-            "Svenska",
-            "Palliativregistret",
-            "pallitative"
-        ],
-        "Information": "Svenska Palliativregistret is a national quality registry that supports systematic improvement of end-of-life care. It collects information on care processes and outcomes and provides feedback for quality improvement and research.",
-        "category": [
-            "National quality registry"
-        ],
-        "start_date": "2005",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapalliativregistret.77633.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister akut lymfatisk leukemi",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/akut-lymfatiskt-leukemi-all/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister akut lymfatisk leukemi"
-        ],
-        "Information": "Established to support the treatment and care of patients diagnosed with this aggressive form of blood cancer, the registry collects comprehensive data on demographics, diagnosis, treatment protocols, and patient outcomes. Data variables include genetic markers, chemotherapy protocols, and remission rates, helping healthcare providers make informed decisions for better outcomes.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "1997",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutlymfatiskleukemiall.83492.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister akut myeloisk leukemi (AML), inklusive akut oklassificerad leukemi (AUL)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/hematologiskacancersjukdomar/akutmyeloiskleukemiamlinklusiveakutoklassificeradleukemiaul/kvalitetsregister.7181.html",
-        "search_tags": [
-            "Nationellt kvalitetsregister akut myeloisk leukemi (AML), inklusive akut oklassificerad leukemi (AUL)"
-        ],
-        "Information": "Focuses on collecting detailed data related to acute myeloid leukemia (AML) and acute undifferentiated leukemia (AUL) in Sweden. This national cancer quality registry collects information on patient demographics, genetic markers, treatment protocols, and outcomes, with the aim of improving the care and survival of patients with these aggressive hematologic malignancies. Includes data from diagnostic processes, chemotherapy, bone marrow transplants, and patient follow-up care. Coverage is comprehensive across Sweden, including nearly all diagnosed patients.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "1997",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutmyeloiskleukemiamlinklusiveakutoklassificeradleukemiaul.83493.html"
-    },
-    {
-        "name": "Nationellt Kvalitetsregister för Bröstcancer NKBC",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/brost/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt Kvalitetsregister för Bröstcancer NKBC"
-        ],
-        "Information": "It collects comprehensive data on breast cancer patients, covering diagnosis, treatments, and outcomes. The registry includes data on tumour characteristics, surgical interventions, radiotherapy, chemotherapy, and hormone therapies, as well as patient demographics. NKBC is crucial for improving the quality of breast cancer care across the country by enabling continuous monitoring and benchmarking of clinical practices. The registry includes nearly all diagnosed breast cancer cases in Sweden.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancernkbc.77549.html"
-    },
-    {
-        "name": "Svenska kvalitetsregistret för gynekologisk cancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/gynekologi/kvalitetsregister/",
-        "search_tags": [
-            "Svenska kvalitetsregistret för gynekologisk cancer"
-        ],
-        "Information": "A registry for gynaecological cancers, covering cancers of the ovaries, uterus, cervix, and vulva. collects detailed information on patient demographics, tumour characteristics, treatments (surgical, radiological, and chemotherapeutic), and follow-up outcomes. Its aim is to enhance the quality of care provided to women diagnosed with gynaecological cancers through systematic data collection and analysis. By monitoring treatment efficacy and patient outcomes across the country, the registry facilitates improvements in clinical practices and supports research efforts. It includes nearly all gynaecological cancer cases treated in Sweden.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakvalitetsregistretforgynekologiskcancer.77571.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister hudmelanom (SweMR)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hud-och-melanom/malignt-melanom/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister hudmelanom (SweMR)"
-        ],
-        "Information": "Focuses on tracking and improving the care and outcomes of patients diagnosed with skin melanoma. The registry collects extensive data on tumour characteristics, treatment approaches (such as surgery and immunotherapy), and patient follow-up information. Key variables include Breslow thickness, ulceration, and metastasis status, all of which are critical for prognosis. The registry covers nearly all melanoma cases diagnosed in Sweden",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2003",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterhudmelanomswemr.77580.html"
-    },
-    {
-        "name": "Svenskt kvalitetsregister för huvud- och halscancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/huvud-och-hals/kvalitetsregister/",
-        "search_tags": [
-            "Svenskt kvalitetsregister för huvud- och halscancer",
-            "throat cancer",
-            "cancer"
-        ],
-        "Information": "The registry focuses on collecting data from patients diagnosed with cancers of the oral cavity, pharynx, larynx, salivary glands, and other related areas. It gathers comprehensive data on tumour characteristics, treatment methods (such as surgery, radiotherapy, and chemotherapy), and patient outcomes. The registry is instrumental in improving the quality of care by enabling continuous monitoring of treatment effectiveness and survival rates. Covers nearly all cases of head and neck cancer in Sweden.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforhuvudochhalscancer.77581.html"
-    },
-    {
-        "name": "Svenska Hypofysregistret",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hypofys/kvalitetsregister-for-hypofystumorer/",
-        "search_tags": [
-            "Svenska Hypofysregistret",
-            "pituitary gland",
-            "cancer"
-        ],
-        "Information": "The Svenska Hypofysregistret is Sweden's national quality registry for pituitary tumours and other related conditions affecting the pituitary gland. The registry collects data on patient demographics, tumour types, treatment protocols (such as surgery, radiotherapy, and medical treatments), and long-term outcomes. It includes detailed information about hormonal imbalances caused by pituitary disorders and tracks the effects of different treatment approaches on patient recovery and quality of life. The registry covers cases from various healthcare providers across Sweden, ensuring that nearly all pituitary tumour patients are included.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2011",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahypofysregistret.77582.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
-            "KLL",
-            "CLL"
-        ],
-        "Information": "The registry aims to collect comprehensive data on patients diagnosed with CLL, including demographic information, genetic markers, treatment approaches, and patient outcomes. Key variables tracked include treatment response, disease progression, and long-term survival rates. The registry provides insights into how different therapeutic strategies affect patient outcomes and supports ongoing clinical research.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2007",
-        "verification_source": "RCC",
-        "verification_url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterkronisklymfatiskleukemikll.84653.html"
-    },
-    {
-        "name": "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lever-och-galla/kvalitetsregister/",
-        "search_tags": [
-            "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
-            "liver",
-            "gallbladder",
-            "cancer"
-        ],
-        "Information": "Sweden’s national quality registry for cancers of the liver, gallbladder, and bile ducts. The registry collects data on patient demographics, tumour characteristics, treatments such as surgery, chemotherapy, and radiotherapy, and long-term outcomes, including survival rates. SweLiv covers nearly all cases of liver, gallbladder, and biliary cancers treated in Sweden, providing a comprehensive dataset that helps guide clinical practice and supports research efforts to improve treatment strategies​.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforcancerilevergallblasaochgallvagarsweliv.77596.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister lymfom",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/lymfom-lymfkortelcancer/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister lymfom"
-        ],
-        "Information": "Sweden’s national quality registry for lymphoma, covering various types of lymphatic cancers such as Hodgkin's lymphoma and non-Hodgkin's lymphoma. Collects detailed data on patient demographics, tumour characteristics, treatment methods (including chemotherapy, immunotherapy, and radiation), and long-term outcomes. It provides comprehensive national coverage, capturing nearly all lymphoma cases treated in Sweden. ",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2000",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterlymfom.84684.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister myelodysplastiskt syndrom",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelodysplastiskt-syndrom-mds/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister myelodysplastiskt syndrom",
-            "blood disorder",
-            "myelodysplastic"
-        ],
-        "Information": "A quality registry for myelodysplastic syndromes, a group of blood disorders that affect the bone marrow and lead to inefficient blood cell production. Collects data on patient demographics, genetic mutations, disease subtypes, treatment protocols (such as supportive care, chemotherapy, and stem cell transplantation), and long-term outcomes. The registry covers nearly all diagnosed cases of MDS in Sweden.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelodysplastisktsyndrommds.84686.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myeloproliferativa-sjukdomar-mpn/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
-            "MPN",
-            "myeloproliferative"
-        ],
-        "Information": "This MPN registry collects data on patient demographics, disease subtypes, genetic markers (such as JAK2 mutations), treatments (including cytoreductive therapy, interferon, and bone marrow transplants), and long-term outcomes like disease progression and survival rates. Covering nearly all diagnosed cases in Sweden, this registry provides valuable insights for standardising treatment protocols and enhancing patient care.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyeloproliferativasjukdomarmpn.84687.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för mastocytos",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/hematologiskacancersjukdomar/mastocytos/kvalitetsregister.11775.html",
-        "search_tags": [
-            "mastocytos",
-            "mastocytosis",
-            "Nationellt kvalitetsregister för mastocytos"
-        ],
-        "Information": "The Swedish National Quality Registry for Mastocytosis collects structured data on patients with mastocytosis to support quality improvement, follow-up and research. The registry is part of the Swedish national cancer quality registry system and is supported by Regionala cancercentrum i samverkan.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2016",
-        "verification_source": "RCC",
-        "verification_url": "https://cancercentrum.se/utvecklingsarbeteutbildning/statistikrapporter/kvalitetsregister/ansvarsupport.8336.html",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister myelom",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelom/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister myelom",
-            "myeloma"
-        ],
-        "Information": "Sweden’s national quality registry for multiple myeloma, a cancer of plasma cells. Collects comprehensive data on patients with myeloma, including patient demographics, genetic markers, disease stage, and treatment regimens such as chemotherapy, immunotherapy, and stem cell transplantation. ",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2008",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelom.84688.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/neuroendokrinabuktumorer/kvalitetsregister.3525.html",
-        "search_tags": [
-            "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
-            "GEP-NET"
-        ],
-        "Information": "The registry collects extensive data on patient demographics, tumour characteristics, genetic markers, treatments (such as surgery, targeted therapies, and peptide receptor radionuclide therapy), and patient outcomes like survival rates and tumour progression. GEP-NET provides nearly complete coverage of cases in Sweden.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2010",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Regionalt kvalitetsregister för skelettmetastaser",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/overgripande-kunskapsstod/skelettmetastaser/",
-        "search_tags": [
-            "Regionalt kvalitetsregister för skelettmetastaser",
-            "bone metastases",
-            "cancer"
-        ],
-        "Information": "Focuses on bone metastases and collects data on cancer type, treatment approaches (such as radiotherapy, surgery, or medication to strengthen bones), and patient outcomes like pain relief, mobility, and survival. The registry covers nearly all cases of skeletal metastases treated in Sweden, making it an essential tool for improving patient care and treatment strategies.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2009",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister sköldkörtelcancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/skoldkortel/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister sköldkörtelcancer",
-            "thyroid cancer",
-            "thyroid"
-        ],
-        "Information": "Sweden’s national quality registry for thyroid cancer, established to monitor and improve the care and outcomes for patients diagnosed with this type of cancer. The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, radioactive iodine therapy, and hormone replacement), and patient outcomes, including survival rates and recurrence.",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2003",
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforskoldkortelcancer.77625.html"
-    },
-    {
-        "name": "Svenskt kvalitetsregister för koloskopier och kolorektalcancerscreening (SveReKKS)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/Screening-tjock-och-andtarmscancer/sverekks/",
-        "search_tags": [
-            "SveReKKS - kvalitetsregister"
-        ],
-        "Information": "Focuses on colorectal cancer screening and prevention. Collects detailed data on screening participation rates, diagnostic results, follow-up procedures, and treatment outcomes. This registry supports Sweden’s organised colorectal cancer screening program, aimed at early detection and treatment of precancerous lesions and cancer in the colon and rectum. ",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "start_date": "2017",
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för analcancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/anal/kvalitetsregister.3263.html",
-        "search_tags": [
-            "Nationellt kvalitetsregister för analcancer"
-        ],
-        "Information": "Sweden’s national quality registry for anal cancer. It was established to improve the diagnosis, treatment, and outcomes of patients with this relatively rare form of cancer. The registry collects data on patient demographics, tumour characteristics, treatment methods (such as chemotherapy, radiotherapy, and surgery), and long-term patient outcomes, including survival rates and recurrence.",
-        "start_date": "2015",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för barncancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/barn/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för barncancer",
-            "peadiatric cancer",
-            "cancer"
-        ],
-        "Information": "Established to improve the care and outcomes for children diagnosed with cancer, it gathers detailed information on patient demographics, cancer types, treatment protocols (such as chemotherapy, radiotherapy, and surgery), and long-term outcomes. The registry covers nearly all cases of paediatric cancer across Sweden, tracking patient survival rates, treatment effectiveness, and any late effects of therapy.",
-        "start_date": "2011",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarncancerregistretsbcr.77539.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/bukspottkortel/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
-            "pancreatic cancer"
-        ],
-        "Information": "The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, chemotherapy, and radiotherapy), and long-term outcomes, including survival rates. Covers nearly all pancreatic cancer cases in Sweden.​",
-        "start_date": "2011",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbukspottkortelcancerpankreasregistret.77552.html"
-    },
-    {
-        "name": "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/gynekologisk-cellprovskontroll/kvalitetsregister/",
-        "search_tags": [
-            "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)"
-        ],
-        "Information": "Includes data on screening, diagnosis, and treatment for cervical cancer across Sweden. It collects information on screening participation, follow-up procedures, and patient outcomes to monitor and improve the effectiveness of the national cervical cancer screening program. The registry covers nearly all eligible women in Sweden who participate in routine screening.",
-        "start_date": "1999",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistretforcervixcancerpreventionnkcx.77597.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hjarna-och-ryggmarg/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
-            "CNS",
-            "brain tumour"
-        ],
-        "Information": "Sweden's national quality registry for brain tumours and central nervous system (CNS) cancers. t collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment methods (such as surgery, radiotherapy, and chemotherapy), and long-term outcomes like survival rates and neurological function.",
-        "start_date": "2009",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhjarntumorerochcentralanervsystemet.77575.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för KML (kronisk myeloisk leukemi)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-myeloisk-leukemi-kml/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för KML",
-            "chronic lyeloid leukemia"
-        ],
-        "Information": "Collects detailed data on patients diagnosed with this specific type of leukemia, tracking treatment methods (such as tyrosine kinase inhibitors), disease progression, and long-term patient outcomes, including survival rates and quality of life. It covers most patients diagnosed with KML in the country. ",
-        "start_date": "2002",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkroniskmyeloiskleukemikml.84685.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för lungcancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lunga-och-lungsack/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för lungcancer",
-            "lung cancer"
-        ],
-        "Information": "It collects comprehensive data on patient demographics, tumour characteristics, diagnostic procedures, treatment approaches (such as surgery, radiotherapy, chemotherapy, and immunotherapy), and long-term outcomes, including survival rates. Covers almost all lung cancer cases in Sweden.",
-        "start_date": "2002",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlungcancer.77599.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/matstrupe-och-magsack/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
-            "gastric cancers",
-            "cancer"
-        ],
-        "Information": "Sweden’s national quality registry for oesophageal and gastric cancers. It collects detailed data on patient demographics, tumour characteristics, diagnostic procedures, treatment modalities (including surgery, chemotherapy, and radiotherapy), and patient outcomes such as survival rates and post-treatment quality of life.",
-        "start_date": "2007",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterformatstrupsochmagsackscancernrev.77553.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för njurcancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/njure/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för njurcancer",
-            "kidney cancer"
-        ],
-        "Information": "The registry tracks patient demographics, tumour characteristics, treatment modalities (such as surgery, targeted therapies, and immunotherapies), and long-term outcomes, including survival rates and quality of life. By covering nearly all kidney cancer cases in Sweden, the registry plays a crucial role in improving treatment standards, facilitating clinical research, and informing national guidelines for managing kidney cancer​.",
-        "start_date": "2005",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfornjurcancer.77607.html"
-    },
-    {
-        "name": "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/prostatacancertestning/kvalitetsregister.7547.html",
-        "search_tags": [
-            "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
-            "prostate cancer",
-            "prostate"
-        ],
-        "Information": "The registry gathers comprehensive data on screening participation, test results (such as PSA levels), diagnostic procedures, and follow-up treatments, ensuring consistency and quality in prostate cancer testing across Sweden.",
-        "start_date": "2023",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för sarkom",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/sarkom/skelettochmjukdelssarkom/kvalitetsregister.3495.html",
-        "search_tags": [
-            "Nationellt kvalitetsregister för sarkom",
-            "ewings sarcoma",
-            "sarcoma"
-        ],
-        "Information": "The registry aims to improve the diagnosis, treatment, and outcomes for patients with various forms of sarcoma, including osteosarcoma, Ewing’s sarcoma, and soft tissue sarcomas. It collects data on patient demographics, tumour characteristics, surgical interventions, chemotherapy, and radiotherapy treatments, as well as long-term outcomes such as recurrence rates and survival.",
-        "start_date": "2009",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för testikelcancer seminom",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/testikel/kvalitetsregister/#:~:text=Det%20nationella%20kvalitetsregistret%20för%20seminom,behandling%20av%20testikelcancer%20i%20Sverige.",
-        "search_tags": [
-            "Nationellt kvalitetsregister för testikelcancer seminom",
-            "prostate cancer"
-        ],
-        "Information": "The registry aims to improve the quality of care by allowing clinics and regions to compare their data with national statistics, providing insights into survival rates, tumour stages, and treatment effectiveness. It also facilitates research, including biobanking initiatives, by providing information on biological samples",
-        "start_date": "2000",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfortestikelcancerseminom.77630.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/tjocktarm-andtarm-och-anal/tjock--och-andtarm/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
-            "colorectal cancer"
-        ],
-        "Information": "The national colorectal cancer registry collects data on diagnosis, surgical treatment, radiotherapy, chemotherapy and outcomes. It supports comparison across hospitals and regions, quality improvement and research in colorectal cancer care.",
-        "start_date": "2007",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakolorektalcancerregistretscrcr.77631.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för urinblåsecancer",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/urinblasa-urinvagar/kvalitetsregister/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för urinblåsecancer",
-            "bladder cancer"
-        ],
-        "Information": "The national bladder cancer registry collects information on tumour stage and grade, treatment such as surgery, radiotherapy, chemotherapy or immunotherapy, and long-term outcomes. It supports uniform quality standards, clinical follow-up and research.",
-        "start_date": "1997",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforurinblasecancer.77554.html"
-    },
-    {
-        "name": "Nationella prostatacancerregistret (NPCR)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://npcr.se/",
-        "search_tags": [
-            "Nationellt kvalitetsregister för prostatacancer",
-            "prostate cancer"
-        ],
-        "Information": "NPCR collects comprehensive data on diagnostic procedures, disease characteristics, treatment, and outcomes for all men diagnosed with prostate cancer in Sweden. Established to support quality improvement and clinical research, NPCR enables benchmarking across healthcare providers and contributes to evidence-based care.",
-        "start_date": "1987",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaprostatacancerregistretnpcr.77615.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister peniscancer (NPECR)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/penis/kvalitetsregister.3518.html",
-        "search_tags": [
-            "Nationellt kvalitetsregister för peniscancer",
-            "penis cancer"
-        ],
-        "Information": "The national penile cancer registry includes newly diagnosed invasive and non-invasive penile cancer and records information on diagnosis, staging, treatment, waiting times and follow-up. It also supports patient-reported outcome and experience measures.",
-        "start_date": "2000",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforpeniscancer.77613.html"
-    },
-    {
-        "name": "Nationellt kvalitetsregister för mammografiscreening (NKM)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/brostcancerscreening/kvalitetsregister",
-        "search_tags": [
-            "Nationellt kvalitetsregister för mammografiscreening",
-            "breast cancer screening"
-        ],
-        "Information": "NKM monitors the entire breast cancer screening process in Sweden, covering invitation, participation, imaging results, and diagnostic follow-up. Targeting women aged 40–74, the registry also includes referred patients of all ages undergoing breast radiology.",
-        "start_date": "about 2020",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancerscreeningnkb.77602.html"
-    },
-    {
-        "name": "Svenskt bråckregister",
-        "registry_centre": [
-            "Registercentrum Norr"
-        ],
-        "url": "https://www.svensktbrackregister.se/",
-        "search_tags": [
-            "hernia",
-            "inguinal hernia"
-        ],
-        "Information": "The Swedish Hernia Register collects nationwide data on inguinal hernia surgeries in patients aged 15 and older. It supports quality improvement, clinical benchmarking, and research in hernia care across Sweden. As of March 2024, the register has merged with the Swedish Ventral Hernia Register (Registret för Svenska Bukväggsbråck), creating a unified national database for both inguinal and ventral hernia surgeries.",
-        "start_date": "1992",
-        "category": [
-            "National quality registry"
-        ],
-        "last_verified": "2026-08-11",
-        "metadata_source": "SKR",
-        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktbrackregister.77598.html"
-    },
-    {
-        "name": "Nationellt onkogenetiskt kvalitetsregister (NOGA)",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/preventiontidigupptackt/arftligcancer/kvalitetsregisterforarftligcancernoga.7556.html",
-        "search_tags": [
-            "Nationellt onkogenetiskt kvalitetsregister (NOGA)"
-        ],
-        "Information": "The National Oncogenetic Quality Registry (NOGA) collects data on individuals undergoing genetic evaluation for hereditary cancer. Its aim is to improve and standardize care across Sweden by monitoring diagnostic lead times, adherence to clinical guidelines, and outcomes. The registry also supports research and quality improvement in hereditary cancer care.",
-        "start_date": "2021",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11"
-    },
-    {
-        "name": "Register för cancerläkemedel",
-        "registry_centre": [
-            "Regionala Cancercentrum i Samverkan"
-        ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerlakemedel/registerforcancerlakemedel.7318.html",
-        "search_tags": [
-            "Register för cancerläkemedel",
-            "cancer drugs",
-            "cancer",
-            "läkemedel"
-        ],
-        "Information": "The Cancer Drug Registry monitors the use of selected cancer medications across Sweden. It consists of 17 regional and one interregional registry, aiming to track treatment patterns, ensure equitable access, and support clinical decision-making. Annual reports provide insights into national trends and regional variations in cancer drug usage.",
-        "start_date": "2018",
-        "category": [
-            "National cancer quality registry"
-        ],
-        "last_verified": "2026-08-11"
-    }
+  {
+    "name": "Barnobesitasregister i Sverige – BORIS",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.e-boris.se/",
+    "search_tags": [
+      "BORIS",
+      "childhood obesity",
+      "Sverige",
+      "obesity"
+    ],
+    "Information": "BORIS is one of the world's largest and oldest registries for the treatment of childhood obesity. It supports quality improvement and research by collecting data on treatment and outcomes in paediatric obesity care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2005",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/barnobesitasregistretisverigeboris.77541.html"
+  },
+  {
+    "name": "Endovaskulär behandling av Stroke – EVAS-registret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://evas-registret.se/",
+    "search_tags": [
+      "stroke",
+      "endovascular",
+      "stroke",
+      "Endovaskulär"
+    ],
+    "Information": "EVAS is, a government funded national quality registry in Sweden for endovascular stroke treatment with full transparency in every aspect. It is based on a modern, top-of-the-line data platform and works in close relationship and shares data with RIKS-STROKE, which is the equivalent for all stroke patients in the country.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2012",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/endovaskularbehandlingavstrokeevasregistret.77562.html"
+  },
+  {
+    "name": "Graviditetsregistret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.medscinet.com/gr/default.aspx",
+    "search_tags": [
+      "Graviditetsregistret",
+      "baby",
+      "prenatal",
+      "postnatal",
+      "fetal",
+      "neonatal"
+    ],
+    "Information": "The Pregnancy Register provides a national foundation of data for maternal and perinatal healthcare. It collects information from maternal healthcare, fetal diagnostics and delivery records to support quality improvement, follow-up and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/graviditetsregistret.77568.html"
+  },
+  {
+    "name": "InfCareHIV",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://infcarehiv.se/",
+    "search_tags": [
+      "HIV",
+      "InfCareHIV",
+      "immune",
+      "virus"
+    ],
+    "Information": "InfCareHIV is a national quality registry that collects longitudinal clinical, laboratory and treatment data for people living with HIV in Sweden. It supports clinical follow-up, quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1983",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehiv.77574.html"
+  },
+  {
+    "name": "InfCareHepatit",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.infcarehepatit.se/",
+    "search_tags": [
+      "liver",
+      "hepatitis",
+      "virus",
+      "InfCareHepatit"
+    ],
+    "Information": "InfCareHepatit is a national quality registry for hepatitis B and C in Sweden. It collects longitudinal clinical, laboratory and treatment data to support quality improvement, follow-up and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehepatit.77573.html"
+  },
+  {
+    "name": "Kvalitetsregister för cystisk fibros – CF-registret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://cf-registret.se/",
+    "search_tags": [
+      "lungs",
+      "cystic fibrosis",
+      "CF-registret"
+    ],
+    "Information": "The aim is to enhance the quality of care, survival rates, and quality of life for all cystic fibrosis (CF) patients in Sweden. It was established as a national quality registry in 2012. Since its inception, the purpose of the registry has been to continuously monitor all individuals with CF over time and ensure equitable and fair care throughout Sweden. The registry is utilised by the four CF centres in Sweden as well as some regional hospitals that treat CF patients.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2012",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterforcystiskfibroscfregistret.77556.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för assisterad befruktning – Q-IVF",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.medscinet.com/qivf/",
+    "search_tags": [
+      "reproduction",
+      "assisted reproduction",
+      "medscinet"
+    ],
+    "Information": "This registry is jointly managed by all IVF clinics in Sweden. The purpose of the registry is to continuously monitor treatment outcomes and any medical risks for both IVF children and the treated couples or women. It also provides participating clinics with data to support their development and quality improvement efforts.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforassisteradbefruktningqivf.77538.html"
+  },
+  {
+    "name": "Svenska hemofiliregistret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://svenskahemofiliregistret.se/",
+    "search_tags": [
+      "hemophilia",
+      "bleeding",
+      "blood",
+      "hemofiliregistret"
+    ],
+    "Information": "Aims to effectively monitor this specific group of patients who often receive lifelong treatment, with the goal of enhancing the quality of care. Key metrics for assessing the effectiveness of the treatment include the annual number of bleeding episodes and joint damage. Joint damage is a long-term consequence of past joint bleeding and is evaluated through functional assessments using joint scores.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2015",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaregistretforblodningssjukdomar.77548.html"
+  },
+  {
+    "name": "Svenska Intensivvårdsregistret – SIR",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.icuregswe.org/",
+    "search_tags": [
+      "SIR",
+      "Intensivvårdsregistret",
+      "intensive care",
+      "Svenska"
+    ],
+    "Information": "SIR aims to monitor and improve the quality of intensive care in Sweden within selected areas that are continuously tracked. Additionally, SIR aims to support the development of methods and research in intensive care, particularly in the field of epidemiology, as well as in other specific areas where collaboration among multiple centers is essential for conducting high-quality scientific studies.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaintensivvardsregistretsir.77587.html"
+  },
+  {
+    "name": "Svenska korsbandsregistret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.aclregister.nu/",
+    "search_tags": [
+      "ACL",
+      "korsbandsregistret"
+    ],
+    "Information": "This registry collects data on anterior cruciate ligament injuries and treatments across Sweden. Its purpose is to improve patient care by tracking surgical techniques, outcomes, and rehabilitation, as well as supporting research and benchmarking clinical practices.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2005-05-01",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskkorsbandsregister.77591.html"
+  },
+  {
+    "name": "Svenska neuroregister",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.neuroreg.se/",
+    "search_tags": [
+      "neuroregister",
+      "nervous system",
+      "neurological treatments",
+      "Svenska"
+    ],
+    "Information": "The Swedish Neuro Register gathers data on patients with neurological diseases such as multiple sclerosis, Parkinson's disease, epilepsy, and neuromuscular disorders. It aims to enhance the quality of care by monitoring treatment outcomes and supporting research into these conditions.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2001",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaneuroregister.77606.html"
+  },
+  {
+    "name": "Svensk Reumatologis Kvalitetsregister – SRQ",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://srq.nu/",
+    "search_tags": [
+      "arthritis",
+      "rheumatic disease",
+      "SRQ"
+    ],
+    "Information": "This registry focuses on patients with rheumatic diseases like rheumatoid arthritis and ankylosing spondylitis. It collects data on disease activity, treatments, and patient outcomes to improve care quality and facilitate research into better management strategies.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1995",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskreumatologiskvalitetsregistersrq.77620.html"
+  },
+  {
+    "name": "Svenskt neonatalt kvalitetsregister – SNQ",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://www.medscinet.com/pnq/",
+    "search_tags": [
+      "newborn",
+      "neonatal care",
+      "neonatalt",
+      "SNQ"
+    ],
+    "Information": "The SNQ collects extensive data on all newborns admitted to neonatal intensive care units (NICUs) in Sweden. This includes demographic information, birth details, diagnoses, treatments, complications, and outcomes. The data covers a wide range of neonatal conditions and interventions, such as respiratory support, infections, congenital anomalies, and more..",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2001",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktneonataltkvalitetsregistersnq.77605.html"
+  },
+  {
+    "name": "InfCare Sprututbyte",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://qrcstockholm.se/kvalitetsregister/anslutna-register",
+    "search_tags": [
+      "Sprututbyte",
+      "needle exchange",
+      "harm reduction",
+      "InfCare"
+    ],
+    "Information": "This registry is part of the InfCare system and collects data on individuals participating in needle exchange programs. This includes demographic details, health status, risk behaviours, and testing for infectious diseases like HIV and hepatitis. The registry also tracks the provision of services such as counselling, vaccinations, and referrals to healthcare or social services.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2016",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt register för levertransplantation",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "http://www.swepharm.se/",
+    "search_tags": [
+      "liver transplant",
+      "levertransplantatation"
+    ],
+    "Information": "This registry collects detailed information on all liver transplant procedures performed in Sweden, including data on donor and recipient characteristics, surgical techniques, post-transplant complications, immunosuppression protocols, and long-term follow-up outcomes such as graft survival and patient survival.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "1998",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Lungfibrosregistret",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://slmf.se/lungfibrosregistret/",
+    "search_tags": [
+      "fibrosis",
+      "Lungfibrosregistret",
+      "lung",
+      "pulmonary"
+    ],
+    "Information": "The register collects data on patients diagnosed with pulmonary fibrosis, including patient demographics, diagnostic criteria, disease severity, treatment regimens, pulmonary function tests, and patient-reported outcomes. It also tracks disease progression and responses to different therapies over time. It aims to include data from all healthcare providers treating patients with pulmonary fibrosis in Sweden, covering both university hospitals and regional clinics. ",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2014",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Svenskt kvalitetsregister för atopiskt dermatit – SwedAD",
+    "registry_centre": [
+      "Kvalitetsregistercentrum Stockholm"
+    ],
+    "url": "https://swedad.nu/",
+    "search_tags": [
+      "skin",
+      "SwedAD",
+      "eczema",
+      "atopic dermatitis"
+    ],
+    "Information": "SwedAD is a national quality registry for atopic dermatitis. It supports follow-up of disease severity, treatment and patient-reported outcomes and is used for quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2019",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Amputations- och Protesregistret Swedeamp",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/swedeamp/",
+    "search_tags": [
+      "amputation",
+      "swedeamp",
+      "prosthetic",
+      "limb"
+    ],
+    "Information": "SwedeAmp collects information on patients undergoing amputations and those fitted with prosthetics. This includes details on the type of amputation, surgical techniques, prosthetic fittings, complications, and rehabilitation outcomes. The registry also tracks patient-reported outcomes related to mobility, function, and quality of life. The registry includes data from all healthcare providers in Sweden that perform amputations and provide prosthetic services, ensuring nationwide coverage",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/amputationsochprotesregisterswedeamp.77535.html"
+  },
+  {
+    "name": "Barnkataraktregistret PECARE",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/pecare",
+    "search_tags": [
+      "paediatric",
+      "PECARE",
+      "eye",
+      "cataract"
+    ],
+    "Information": "PECARE focuses on children with cataracts, collecting data on diagnosis, surgical treatments, visual outcomes, and follow-up care. It also tracks complications and the use of visual aids post-surgery. The registry aims to improve understanding and management of paediatric cataracts in Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2006",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "BPSD – Svenskt register för Beteendemässiga och Psykiska Symptom vid Demens",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://bpsd.se/",
+    "search_tags": [
+      "BPSD",
+      "dementia",
+      "psychological",
+      "demens"
+    ],
+    "Information": "The BPSD register collects data on individuals with dementia who exhibit behavioural and psychological symptoms. It includes information on symptom types and severity, pharmacological and non-pharmacological treatments, and care plans. The registry aims to improve the management of dementia-related symptoms and enhance patient care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforbeteendemassigaochpsykiskasymtomviddemenssjukdombpsd.77557.html"
+  },
+  {
+    "name": "CPUP – Uppföljningsprogram för Cerebral Pares",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "http://cpup.se/",
+    "search_tags": [
+      "treatment",
+      "palsy",
+      "cerebral palsy",
+      "cpup"
+    ],
+    "Information": "CPUP collects comprehensive data on individuals with cerebral palsy, including demographic information, motor function, associated conditions, interventions, and outcomes. It tracks long-term development and care needs, with an emphasis on preventing complications and improving quality of life. The program covers all children and adults with cerebral palsy in Sweden who receive specialised care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/cerebralparesuppfoljningsprogramcpup.77555.html"
+  },
+  {
+    "name": "HAKIR – Handkirurgiskt kvalitetsregister",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/hakir/",
+    "search_tags": [
+      "hand",
+      "HAKIR",
+      "surgery",
+      "reconstruction"
+    ],
+    "Information": "HAKIR gathers data on patients undergoing hand surgery, including surgical details, complications, rehabilitation processes, and functional outcomes. It also collects patient-reported outcomes related to hand function and quality of life, which are crucial for assessing the success of various surgical procedures.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/handkirurgisktkvalitetsregisterhakir.77572.html"
+  },
+  {
+    "name": "Könsdysforiregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/konsdysforiregistret",
+    "search_tags": [
+      "dysphoria",
+      "gender",
+      "identity",
+      "Könsdysforiregistret"
+    ],
+    "Information": "This registry collects data on individuals undergoing assessment and treatment for gender dysphoria, including demographic information, psychological evaluations, medical and surgical treatments, and follow-up outcomes. It aims to monitor the quality of care provided to individuals with gender dysphoria and to support research in this field.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2017",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "LKG-registret – Nationellt kvalitetsregister för läpp- käk- och/eller gomspalt",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://lkg-registret.se/",
+    "search_tags": [
+      "cleft lip",
+      "lip",
+      "palate"
+    ],
+    "Information": "Contains data on patients born with cleft lip, cleft palate, or both. It includes information on diagnosis, surgical interventions, follow-up care, speech and language outcomes, dental health, and psychosocial aspects. Data on patient demographics, types of clefts, and the timing and types of surgical procedures are also gathered. It has national coverage and includes data from all specialist centres in Sweden that treat cleft lip and palate. ",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlappkakochgomspaltlkgregistret.77600.html"
+  },
+  {
+    "name": "MMCUP – Kvalitetsregister för MMC (myelomeningocele) och annan neuralrörsdefekt",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://mmcup.se/",
+    "search_tags": [
+      "MMCUP",
+      "myelomeningocele",
+      "neural tube defect"
+    ],
+    "Information": "MMCUP is a follow-up programme and quality registry for people with myelomeningocele and related conditions. It supports systematic follow-up of function, interventions, complications and outcomes across Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterformmcannanneuralrorsdefektochhydrocefalusmmcup.77622.html"
+  },
+  {
+    "name": "Nationella Kataraktregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://kataraktreg.se/",
+    "search_tags": [
+      "eye",
+      "vision",
+      "cataract"
+    ],
+    "Information": "The National Cataract Register gathers data on cataract surgery in Sweden, including patient characteristics, surgical techniques, intraocular lenses, complications and visual outcomes. It supports quality monitoring, comparison between units and research in ophthalmic surgery.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1992",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakataraktregistret.77569.html"
+  },
+  {
+    "name": "Nationella Kvalitetsregistret för Infektionssjukdomar",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://infektionsregistret.se/",
+    "search_tags": [
+      "pathogen",
+      "infectious disease",
+      "infectious",
+      "infektionsregistret"
+    ],
+    "Information": "This registry collects data on patients diagnosed with various infectious diseases, including HIV, hepatitis, and tuberculosis. Information includes demographics, diagnostics, treatments, disease progression, and outcomes, as well as data on antimicrobial resistance and healthcare-associated infections. It covers most patients with infectious diseases treated in hospitals and clinics. ",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "RIKSHÖFT",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/rikshoft/",
+    "search_tags": [
+      "RIKSHÖFT",
+      "fracture",
+      "hip",
+      "bone"
+    ],
+    "Information": "RIKSHÖFT follows hip-fracture care and outcomes in Sweden to support comparison, quality improvement and research across the care pathway.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1988",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhoftfrakturrikshoft.77583.html"
+  },
+  {
+    "name": "SKaPa – Svenskt kvalitetsregister för Karies och Parodontit",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "http://www.skapareg.se/",
+    "search_tags": [
+      "Parodontit",
+      "dental caries",
+      "SKaPa",
+      "periodontitis"
+    ],
+    "Information": "SKaPa collects data on dental health, focusing on caries (tooth decay) and periodontitis (gum disease). Information includes dental examinations, treatment methods, preventive measures, and outcomes.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforkariesochparodontitskapa.77589.html"
+  },
+  {
+    "name": "SKRS – Svenskt Kvalitetsregister för Rehabilitering vid Synnedsättning",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/skrs",
+    "search_tags": [
+      "Synnedsättning",
+      "vision rehabilitation",
+      "eyesight"
+    ],
+    "Information": "SKRS collects data on individuals undergoing rehabilitation for visual impairment, including types of visual impairments, rehabilitation interventions, assistive devices used, and functional outcomes. The register includes data from all vision rehabilitation centres across Sweden, aiming for complete national coverage",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2015",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforrehabiliteringvidsynnedsattningskrs.77619.html"
+  },
+  {
+    "name": "SQRTPA – Scandinavian Quality Register for Thyroid, Parathyroid and Adrenal surgery",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://sqrtpa.se/",
+    "search_tags": [
+      "parathyroid",
+      "thyroid",
+      "Adrenal",
+      "endocrine"
+    ],
+    "Information": "Data on patients undergoing surgery on the thyroid, parathyroid, or adrenal glands. It includes patient demographics, diagnoses, surgical details, pathology results, complications, and long-term outcomes. The registry includes data from major hospitals and surgical centres in Sweden, as well as in other Scandinavian countries.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2004",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianqualityregisterforthyroidparathyroidandadrenalsurgerysqrtpa.77561.html"
+  },
+  {
+    "name": "Svenska Cornearegistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/cornea",
+    "search_tags": [
+      "transplant",
+      "corneal",
+      "Cornearegistret",
+      "vision"
+    ],
+    "Information": "Collects data on corneal surgeries, including corneal transplants. It tracks patient demographics, surgical techniques, donor and recipient details, complications, and visual outcomes. The registry includes data from all ophthalmology departments performing corneal surgeries in Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1996",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskacornearegistret.77579.html"
+  },
+  {
+    "name": "Svenska Nationella Fotledsregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://swedankle.se/",
+    "search_tags": [
+      "orthopedics",
+      "surgery",
+      "ankle",
+      "ankle surgery"
+    ],
+    "Information": "Data on ankle surgeries, including fracture types, surgical techniques, complications, rehabilitation, and functional outcomes such as mobility and pain.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1997",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskanationellafotledsregistret.77563.html"
+  },
+  {
+    "name": "Svenska Makularegistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://makulareg.se/",
+    "search_tags": [
+      "macular",
+      "eye",
+      "retina",
+      "macular diseases"
+    ],
+    "Information": "The registry gathers data on patients with macular diseases, such as age-related macular degeneration (AMD). It includes information on diagnosis, treatments (especially anti-VEGF injections), visual outcomes, and patient-reported outcomes. Includes data from all ophthalmology clinics treating macular diseases in Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskamakularegistret.77601.html"
+  },
+  {
+    "name": "Svenska Skulder- och Armbågsregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/ssar",
+    "search_tags": [
+      "shoulder and elbow",
+      "Armbågsregistret",
+      "shoulder"
+    ],
+    "Information": "Data on shoulder and elbow surgeries, including patient demographics, diagnoses, surgical procedures, rehabilitation, complications, and outcomes such as range of motion and pain.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1999",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaskulderocharmbagsregistret.77624.html"
+  },
+  {
+    "name": "SweTrau – Svenska Traumaregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://swetrau.se/",
+    "search_tags": [
+      "SweTrau",
+      "Traumaregistret",
+      "trauma",
+      "injury"
+    ],
+    "Information": "SweTrau collects data on trauma patients, including types of injuries, severity, treatments provided, and outcomes such as survival rates and functional recovery. The registry includes data from all major trauma centres and emergency departments in Sweden, ensuring comprehensive national coverage of trauma care and outcomes.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskatraumaregistret.77632.html"
+  },
+  {
+    "name": "AmbuReg – Ambulansregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/ambureg/",
+    "search_tags": [
+      "paramedic",
+      "AmbuReg",
+      "ambulance",
+      "emergency"
+    ],
+    "Information": "AmbuReg is the national quality registry for ambulance care in Sweden. It supports quality improvement, follow-up and comparison of prehospital emergency care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2016",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Analfistelregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "Analfistelregistret",
+      "colorectal",
+      "anal",
+      "fistula"
+    ],
+    "Information": "This registry collects information on patients undergoing treatment for anal fistulas, including demographic data, types of fistulas, surgical and non-surgical treatments, complications, and outcomes such as healing rates and recurrence.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "GamReg Sweden – Kvalitetsregister för spel- och dataspelsberoende",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register/gamreg-sweden",
+    "search_tags": [
+      "gamreg",
+      "addiction",
+      "gambling addiction",
+      "gaming addiction"
+    ],
+    "Information": "GamReg collects data on individuals seeking treatment for gambling and gaming addiction. This includes information on demographics, types of addiction, treatments provided (such as counselling or medication), and outcomes related to addiction severity and recovery. The registry covers multiple treatment centres and clinics across Sweden that specialise in addiction therapy.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2019",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Glaukomregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "optic nerve",
+      "glaucoma",
+      "vision",
+      "Glaukomregistret"
+    ],
+    "Information": "The Glaucoma Register collects data on patients diagnosed with glaucoma, including patient demographics, diagnostic criteria, intraocular pressure measurements, visual field data, treatments (medications or surgeries), and outcomes.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "LHON-registret – Registret för Lebers Hereditära Opticusneuropati",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://lhon-registret.se/",
+    "search_tags": [
+      "optic",
+      "Lebers",
+      "Leber's hereditary optic neuropathy",
+      "LHON-registret"
+    ],
+    "Information": "The Swedish LHON Registry is currently a research registry for Leber hereditary optic neuropathy (LHON). Its primary purpose is to facilitate research projects and improve knowledge about the condition.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2018",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "LSR – Lund Stroke Register",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://portal.research.lu.se/sv/projects/lund-stroke-register",
+    "search_tags": [
+      "endovascular",
+      "Register",
+      "stroke",
+      "LSR"
+    ],
+    "Information": "The Lund Stroke Register collects data on patients admitted to the Lund University Hospital with a diagnosis of stroke. Data includes patient demographics, stroke type and severity, treatments provided, rehabilitation, and outcomes. The registry specifically covers patients treated at Lund University Hospital, providing detailed insights into stroke care and outcomes within this institution.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2001",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Njurtransplantationsregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "Njurtransplantationsregistret",
+      "renal",
+      "transplant",
+      "kidney"
+    ],
+    "Information": "Collects data on kidney transplant procedures and outcomes.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Barnkirurgi operationsregister",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "paediatric surgeries",
+      "Barnkirurgi"
+    ],
+    "Information": "Monitors outcomes of paediatric surgeries.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Register för brachyterapi vid uvealt melanom",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "melanoma",
+      "brachytherapy",
+      "Register",
+      "uveal melanoma"
+    ],
+    "Information": "Tracks outcomes of brachytherapy for uveal melanoma.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Sklerodermiregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "skin",
+      "autoimmune",
+      "Sklerodermiregistret",
+      "scleroderma"
+    ],
+    "Information": "Monitors treatment outcomes for scleroderma patients.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Svenska Lambåregistret",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "Svenska",
+      "Lambåregistret"
+    ],
+    "Information": "Tracks outcomes of flap surgeries and patient recovery.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "SweAAA – Svenskt Register för Abdominellt Aortaaneurysm",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://rcsyd.se/anslutna-register",
+    "search_tags": [
+      "aortic",
+      "abdominal aortic aneurysm",
+      "vascular"
+    ],
+    "Information": "Monitors outcomes of abdominal aortic aneurysm treatments.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "RaraSwed – Nationellt kvalitetsregister för sällsynta hälsotillstånd",
+    "registry_centre": [
+      "Registercentrum Syd"
+    ],
+    "url": "https://sodrasjukvardsregionen.se/csd-syd/raraswed-kvalitetsregister/",
+    "search_tags": [
+      "RaraSwed",
+      "rare disease",
+      "genetic",
+      "Sällsynta diagnoser",
+      "sällsynta hälsotillstånd"
+    ],
+    "Information": "RaraSwed is the Swedish national quality registry for rare health conditions. It collects structured information across rare diagnoses to support quality improvement, follow-up and research and to improve knowledge about healthcare and outcomes for people living with rare conditions.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "PsoReg – Nationellt register för systembehandling av psoriasis",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://psoreg.se/",
+    "search_tags": [
+      "skin",
+      "psoriasis",
+      "PsoReg",
+      "psoriasis treatment"
+    ],
+    "Information": "PsoReg tracks patients undergoing systemic treatment for psoriasis, collecting data on treatment efficacy, patient demographics, disease severity, and quality of life. It covers dermatology clinics across Sweden, aiming for nationwide coverage to monitor long-term outcomes and improve patient care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2006",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registerforsystembehandlingavpsoriasispsoreg.77616.html"
+  },
+  {
+    "name": "Riksstroke – Nationellt kvalitetsregister för strokesjukvård",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://www.riksstroke.org/sve/",
+    "search_tags": [
+      "Riksstroke",
+      "endovascular",
+      "stroke",
+      "kvalitetsregister"
+    ],
+    "Information": "Riksstroke gathers data on stroke care, including patient characteristics, acute treatment, rehabilitation, and long-term follow-up. It covers all hospitals in Sweden, ensuring comprehensive national coverage, and provides insights into stroke outcomes and healthcare quality improvements.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1994",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakvalitetsregistretforstrokeriksstroke.77627.html"
+  },
+  {
+    "name": "Svenskt Bråckregister – Nationellt kvalitetsregister inom bråckkirurgi",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://svensktbrackregister.se/",
+    "search_tags": [
+      "bråck",
+      "hernia",
+      "inguinal hernia",
+      "ventral hernia",
+      "bukväggsbråck"
+    ],
+    "Information": "The Swedish Hernia Register collects nationwide data on inguinal hernia surgeries in patients aged 15 and older, including patient demographics, surgical techniques, complications and outcomes such as recurrence rates. It supports quality improvement, clinical benchmarking and research in hernia care across Sweden. As of March 2024, the register has merged with the Swedish Ventral Hernia Register (Registret för Svenska Bukväggsbråck), creating a unified national database for both inguinal and ventral hernia surgeries.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1992",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktbrackregister.77598.html"
+  },
+  {
+    "name": "GynOp – Nationella kvalitetsregister inom gynekologisk kirurgi",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://www.gynop.se/",
+    "search_tags": [
+      "gynecological surgeries",
+      "GynOp",
+      "gynecological"
+    ],
+    "Information": "Tracks outcomes of gynaecological surgeries, collecting data on patient demographics, surgical methods, complications, and recovery. It covers nearly all hospitals in Sweden performing gynaecological surgeries, offering extensive national coverage to improve surgical outcomes and patient safety. The register includes the following subregisters: Intrauterin kirurgi; Rekonstruktiv bäckenbottenkirurgi; Inkontinens; Bristning; Hysterektomi, adnex- och endometrioskirurgi",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterinomgynekologiskkirurgigynop.77570.html"
+  },
+  {
+    "name": "SveATTR – Svenska transtyretinamyloidosregistret",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://regionvasterbotten.se/for-vardgivare/kunskapsstod/kvalitetsregistret-sveattr",
+    "search_tags": [
+      "transtyretinamyloidosregistret",
+      "SveATTR"
+    ],
+    "Information": "SveATTR collects data on patients with transthyretin amyloidosis and genetic carriers. It tracks patient demographics, treatments, and outcomes to improve care and facilitate research. It includes data from hospitals across Sweden,",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2019",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "DBS – Kvalitetsregister inom deep brain stimulation",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://rcnorr.se/anslutna-register/",
+    "search_tags": [
+      "DBS",
+      "stimulation",
+      "deep brain"
+    ],
+    "Information": "The registry tracks patients undergoing deep brain stimulation (DBS) for movement disorders. It collects data on surgical procedures, outcomes, and complications. Coverage includes hospitals performing DBS in Sweden​,",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "CKG – Kardiovaskulär genetik",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://www.regionvasterbotten.se/forskning/profilomraden/kardiovaskular-genetik",
+    "search_tags": [
+      "Kardiovaskulär",
+      "genetik",
+      "CKG",
+      "Cardiovascular"
+    ],
+    "Information": "This registry collects data on patients with genetic cardiovascular conditions, focusing on genetic information, treatments, and patient outcomes. It aims for national coverage​.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "Unknown",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Terapeutisk aferes – Internationellt register för terapeutisk aferes behandling",
+    "registry_centre": [
+      "Registercentrum Norr"
+    ],
+    "url": "https://www.waa-registry.org/",
+    "search_tags": [
+      "aferes"
+    ],
+    "Information": "This international registry gathers data on therapeutic apheresis treatments, tracking patient demographics, procedures, and outcomes to improve treatment protocols across participating countries​.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "1992",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "AURICULA – Nationellt register för förmaksflimmer och antikoagulation",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/auricula/",
+    "search_tags": [
+      "atrial fibrillation",
+      "aFib"
+    ],
+    "Information": "This registry collects data on patients with atrial fibrillation, focusing on diagnostic procedures, treatments, and outcomes to improve care for those requiring anticoagulation. It covers hospitals and clinics across Sweden​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "GallRiks – Svenskt kvalitetsregister för gallstenskirurgi",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/gallriks/",
+    "search_tags": [
+      "GallRiks",
+      "cholecystectomy",
+      "gallstone surgery"
+    ],
+    "Information": "GallRiks is Sweden's national quality registry for gallstone surgery and ERCP. It records gallbladder surgery, ERCP procedures and postoperative complications and supports quality monitoring, comparison between units and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2005",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforgallstenskirurgiochercpgallriks.77567.html"
+  },
+  {
+    "name": "Kateterablationsregistret – Nationellt kvalitetsregister för kateterablation vid hjärtrusningar",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/kateterablation/",
+    "search_tags": [
+      "kateterablation",
+      "cardiovascular"
+    ],
+    "Information": "This registry collects data on catheter ablation for arrhythmias, including procedural details and patient outcomes. It covers Swedish hospitals performing these procedures​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2004",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkateterablation.77544.html"
+  },
+  {
+    "name": "NRS – Nationellt register över smärtrehabilitering",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/nrs/",
+    "search_tags": [
+      "pain",
+      "pain rehab"
+    ],
+    "Information": "NRS gathers data on patients undergoing pain rehabilitation for chronic pain. It collects information on treatments, rehabilitation plans, and patient-reported outcomes to monitor and improve the quality of life for these patients. NRS covers clinics across Sweden and is aimed at both short- and long-term outcome analysis​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisteroversmartrehabiliteringnrs.77626.html"
+  },
+  {
+    "name": "RiksSvikt – Nationellt kvalitetsregister för hjärtsvikt",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/rikssvikt/",
+    "search_tags": [
+      "RiksSvikt",
+      "hear disease"
+    ],
+    "Information": "RiksSvikt is a national quality registry for heart failure. It collects data on diagnostics, treatment and long-term outcomes to support guideline-based care, quality improvement and research across Swedish hospitals.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2003",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellthjartsviktsregisterrikssvikt.77578.html"
+  },
+  {
+    "name": "RiksSår – Nationellt kvalitetsregister för svårläkta sår",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.rikssar.se/",
+    "search_tags": [
+      "svårläkta",
+      "RiksSår",
+      "wound"
+    ],
+    "Information": "This registry gathers data on patients with chronic wounds, focusing on wound types, treatments, and healing outcomes. It aims to improve care for patients with non-healing wounds and involves both primary and specialist care facilities across Sweden​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforpatientermedsvarlaktasarrikssar.77628.html"
+  },
+  {
+    "name": "Senior alert – Nationellt kvalitetsregister för vård och omsorg",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.senioralert.se/",
+    "search_tags": [
+      "Senior",
+      "senior alert",
+      "treatment"
+    ],
+    "Information": "Senior alert is a national quality registry and a tool for preventive care. It supports systematic prevention and follow-up of risks including falls, pressure ulcers, malnutrition, poor oral health and bladder dysfunction.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforvardochomsorgsenioralert.77634.html"
+  },
+  {
+    "name": "SOReg – Scandinavian Obesity Surgery Registry",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.soreg.se/",
+    "search_tags": [
+      "Obesity",
+      "Scandinavian",
+      "Surgery",
+      "SOReg"
+    ],
+    "Information": "SOReg is a quality registry for bariatric surgery. It follows procedures, complications, weight outcomes and long-term follow-up and supports quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianobesitysurgeryregistersoreg.77611.html"
+  },
+  {
+    "name": "SPAHR – Svenska PAH och CTEPH-registret",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/spahr/",
+    "search_tags": [
+      "registret",
+      "CTEPH",
+      "SPAHR"
+    ],
+    "Information": "SPAHR is a national quality registry for pulmonary arterial hypertension (PAH) and chronic thromboembolic pulmonary hypertension (CTEPH). It follows diagnosis, treatment, function, quality of life and prognosis and supports national comparison, quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapahochctephregistretspahr.77584.html"
+  },
+  {
+    "name": "SPOR – Svenskt perioperativt register",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://spor.se/",
+    "search_tags": [
+      "register",
+      "SPOR",
+      "UCR",
+      "perioperativt"
+    ],
+    "Information": "SPOR is a national quality registry that collects perioperative data for patients undergoing surgery. It supports patient safety, quality improvement, national comparison and research across perioperative care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktperioperativtregisterspor.77610.html"
+  },
+  {
+    "name": "SveDem – Svenska registret för kognitiva sjukdomar/demenssjukdomar",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/svedem/",
+    "search_tags": [
+      "Cognitive",
+      "Dementia",
+      "UCR",
+      "SveDem"
+    ],
+    "Information": "SveDem, the Swedish Registry for Cognitive/Dementia Disorders, supports systematic follow-up of diagnosis, treatment, care and support for people with cognitive disorders. It is used for quality improvement, national follow-up and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforkognitivasjukdomardemenssjukdomarsvedem.77558.html"
+  },
+  {
+    "name": "SWEDCON – Barnhjärtregistret (inkluderar GUCH, det vill säga vuxna med medfött hjärtfel)",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/swedcon/",
+    "search_tags": [
+      "GUCH",
+      "children",
+      "heart",
+      "SWEDCON"
+    ],
+    "Information": "SWEDCON focuses on congenital heart disease, tracking surgeries, treatments, and outcomes for children and adults with congenital heart defects. It includes all centres in Sweden treating congenital heart disease, ensuring comprehensive national coverage​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1998",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterformedfoddahjartsjukdomarswedcon.77603.html"
+  },
+  {
+    "name": "SWEDEHEART – Sammanslagning av RIKS-HIA, SEPHIA, SCAAR, TAVI, Svenska Hjärtkirurgiregistret och Kardiogenetikregistret.",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/swedeheart/",
+    "search_tags": [
+      "SEPHIA",
+      "SCAAR",
+      "TAVI",
+      "SwEDEHEART"
+    ],
+    "Information": "SWEDEHEART is a national registry that includes data from acute coronary care (RIKS-HIA), coronary angiography (SCAAR), heart surgery, and secondary prevention (SEPHIA). It covers nearly all cardiac care units in Sweden, providing comprehensive data on heart disease management",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforhjartintensivvardkranskarlsrontgenpcihjartkirurgiochsekundarpreventionswedeheart.77576.html"
+  },
+  {
+    "name": "SWEDEVOX – Andningssviktregistret över oxygenbehandling och respiratorbehandling i hemmet",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/swedevox/",
+    "search_tags": [
+      "oxygen",
+      "UCR",
+      "SWEDEVOX"
+    ],
+    "Information": "This registry collects data on patients receiving oxygen or ventilator therapy for respiratory failure at home. It tracks treatment outcomes and covers hospitals providing these services across Sweden​.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/andningssviktsregistretswedevox.77536.html"
+  },
+  {
+    "name": "SWEDVASC – Nationellt register för kärlkirurgi",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/swedvasc/",
+    "search_tags": [
+      "vain",
+      "SWEDVASC"
+    ],
+    "Information": "SWEDVASC is the national quality registry for vascular surgery. It follows procedures such as aneurysm repair and treatment of peripheral artery disease and supports quality improvement, comparison and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1994",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkarlkirurgiswedvasc.77592.html"
+  },
+  {
+    "name": "SVAR – Svenskt akutvårdsregister",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/svar/",
+    "search_tags": [
+      "acute",
+      "SVAR",
+      "acute care"
+    ],
+    "Information": "SVAR is a national registry covering the emergency care pathway, including prehospital care, emergency departments and acute wards. It supports quality improvement and follow-up of emergency care across Sweden.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "TBI – Traumatic Brain Injury",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/tbi/",
+    "search_tags": [
+      "TBI",
+      "Brain",
+      "Injury",
+      "Traumatic"
+    ],
+    "Information": "The Traumatic Brain Injury registry collects data on patients with severe brain injuries, focusing on trauma mechanisms, treatments, and rehabilitation outcomes. While no specific patient numbers were found, this registry is part of broader national efforts to improve care for trauma patients across Sweden​.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "ThoR – Allmän Thoraxkirurgi",
+    "registry_centre": [
+      "Uppsala Clinical Research Center"
+    ],
+    "url": "https://www.ucr.uu.se/thor/",
+    "search_tags": [
+      "ThoR",
+      "Thorax",
+      "Thoraxkirurgi"
+    ],
+    "Information": "Collects data on surgeries involving the lungs, trachea, esophagus, pleura, pericardium, thymus, diaphragm, and the chest wall including bones and muscles. While a significant portion of the surgeries focus on lung cancer, it also includes data on surgeries for benign conditions. The registry tracks surgical outcomes and complications to improve thoracic surgery care across Sweden​.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "BRIMP – Bröstimplantatregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://brimp.registercentrum.se/",
+    "search_tags": [
+      "Breast implant",
+      "Bröstimplantatregistret",
+      "BRIMP"
+    ],
+    "Information": "BRIMP is the national breast implant registry. It collects data on cosmetic and reconstructive breast implant procedures, implant types, surgical methods and complications to support patient safety and quality improvement.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2014",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/brostimplantatregistret.77550.html"
+  },
+  {
+    "name": "Kranio – Kranioregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://kranio.registercentrum.se/",
+    "search_tags": [
+      "Kranioregistret",
+      "Kranio",
+      "cranial"
+    ],
+    "Information": "This registry collects data on patients undergoing cranial surgery for congenital malformations, trauma, or other conditions. It tracks surgical outcomes, complications, and long-term recovery but does not have widely available patient numbers. Coverage includes hospitals performing cranial surgeries across Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2023",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "LVR – Luftvägsregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://lvr.registercentrum.se/",
+    "search_tags": [
+      "Luftvägsregistret",
+      "LVR",
+      "airways"
+    ],
+    "Information": "LVR gathers data on respiratory disorders, particularly focusing on patients requiring long-term oxygen or ventilator support. The registry tracks treatment types, patient demographics, and outcomes across Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/luftvagsregistret.77590.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för öron-, näs- och halssjukvård",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://orl.registercentrum.se/",
+    "search_tags": [
+      "ear",
+      "nose",
+      "throat",
+      "treatment"
+    ],
+    "Information": "Tracks treatments and outcomes for various ENT conditions. It includes nine sub-registries: surgery for hearing improvement with stapes prostheses, nasal septum surgery, tympanostomy tube surgeries, vocal cord surgery, hearing rehabilitation with hearing aids, cochlear implants, tonsillectomy, eardrum repair surgeries, and snoring surgeries. These registries cover hospitals and clinics across Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1997",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfororonnasochhalssjukvard.81907.html"
+  },
+  {
+    "name": "NDR – Nationella Diabetesregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://ndr.registercentrum.se/",
+    "search_tags": [
+      "NDR",
+      "Nationella",
+      "Diabetes"
+    ],
+    "Information": "The National Diabetes Register collects data on diabetes care, risk factors, treatment and outcomes. It is used for quality improvement, benchmarking, follow-up and research in Swedish diabetes care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1996",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelladiabetesregistretndr.77559.html"
+  },
+  {
+    "name": "NROK – Nationella registret för ortognatkirurgi",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://nrok.registercentrum.se/",
+    "search_tags": [
+      "orthognathic surgery",
+      "NROK"
+    ],
+    "Information": "This registry collects data on 900-1000 corrective jaw surgeries annually in Sweden. The focus is on improving care quality and ensuring equal access to treatment for patients with dentofacial anomalies. It tracks surgical outcomes and patient safety, helping to ensure consistent standards of care across clinics​",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2018",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "QregPV – Primärvårdens kvalitetsregister Västra Götaland",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://qregpv.registercentrum.se/",
+    "search_tags": [
+      "QregPV"
+    ],
+    "Information": "QregPV is a regional quality registry for primary care in Vastra Gotaland. It supports systematic follow-up and quality improvement in primary care by compiling relevant clinical indicators and outcomes.",
+    "category": [
+      "Other quality registry"
+    ],
+    "start_date": "2006",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Riksfot – Svenska fotkirurgiska registret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://fot.registercentrum.se/",
+    "search_tags": [
+      "foot",
+      "feet",
+      "Riksfot",
+      "surgery"
+    ],
+    "Information": "Riksfot is the Swedish foot surgery registry. It follows foot and ankle surgical procedures, patient characteristics and outcomes to support quality improvement, comparison between units and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafotkirurgiskaregistretriksfot.77564.html"
+  },
+  {
+    "name": "SESAR – Svenska Sömnapnéregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://sesar.registercentrum.se/",
+    "search_tags": [
+      "apnea",
+      "SESAR",
+      "sleep apnea"
+    ],
+    "Information": "SESAR is a national quality registry for sleep apnoea. It follows diagnosis, treatment and follow-up of patients with suspected or confirmed sleep apnoea, mainly obstructive sleep apnoea, and supports quality improvement and service development.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskasomnapneregistretsesar.77629.html"
+  },
+  {
+    "name": "SFR – Svenska Frakturregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://sfr.registercentrum.se/",
+    "search_tags": [
+      "SFR",
+      "fracture"
+    ],
+    "Information": "The Swedish Fracture Register follows fractures treated in Sweden, including fracture characteristics, injury mechanisms, treatment and outcomes for both surgical and non-surgical care. It supports clinical feedback, quality improvement and research in fracture care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafrakturregistret.77565.html"
+  },
+  {
+    "name": "SLR – Svenska Ledprotesregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://slr.registercentrum.se/",
+    "search_tags": [
+      "Ledprotesregistret",
+      "prothese",
+      "SLR"
+    ],
+    "Information": "This is a national quality registry that tracks all hip and knee joint replacement surgeries, including primary operations, revisions, and osteotomies (surgical bone cuts to correct alignment) performed across Sweden. The registry was officially established in 2020 after merging two previously separate registers—the Swedish Hip Arthroplasty Register (started in 1979) and the Swedish Knee Arthroplasty Register (started in 1975). Since then, SLR has been systematically collecting data to monitor and improve the quality of joint replacement surgeries nationwide​. The registry covers all units performing joint replacements in Sweden, ensuring a very high coverage rate.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2020",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaledprotesregistret.77595.html"
+  },
+  {
+    "name": "SPOQ – Svenskt Pediatriskt Ortopediskt Qvalitetsregister",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://spoq.registercentrum.se/",
+    "search_tags": [
+      "Ortopediskt",
+      "orthopedic",
+      "child",
+      "Pediatric care"
+    ],
+    "Information": "SPOQ is a national quality registry for paediatric orthopaedics. It focuses on conditions such as developmental dysplasia of the hip, Perthes disease, slipped capital femoral epiphysis, clubfoot and patellar dislocation, and supports timely diagnosis, treatment follow-up and quality improvement.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2015",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktpediatrisktortopedisktqvalitetsregisterspoq.77612.html"
+  },
+  {
+    "name": "Svenska Artrosregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://boa.registercentrum.se/",
+    "search_tags": [
+      "svenska artros",
+      "arthritis"
+    ],
+    "Information": "Svenska Artrosregistret is a national quality registry that follows first-line osteoarthritis care and patient-reported outcomes. It is used for quality improvement, service follow-up and research in osteoarthritis care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaartrosregistret.77537.html"
+  },
+  {
+    "name": "Svenska Hjärt- lungräddningsregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://shlr.registercentrum.se/",
+    "search_tags": [
+      "cardiopulmonary resuscitation"
+    ],
+    "Information": "The Swedish Registry of Cardiopulmonary Resuscitation collects data on cardiac-arrest events and the critical links in the chain of survival, both in and outside hospital. It supports quality improvement, comparison and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1990",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahjartlungraddningsregistret.77577.html"
+  },
+  {
+    "name": "Svenska Thoraxtransplantationsregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://strax.registercentrum.se/",
+    "search_tags": [
+      "Thoraxtransplantationsregistret",
+      "transplant"
+    ],
+    "Information": "The Swedish Thoracic Transplant Registry follows heart and lung transplantation, including waiting-list information, perioperative care and long-term follow-up. It supports quality monitoring and research in thoracic transplantation.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2018",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Svenskt Register för Rehabiliteringsmedicin",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://svereh.registercentrum.se/",
+    "search_tags": [
+      "rehab",
+      "rehabilitation",
+      "Rehabiliteringsmedicin",
+      "svereh"
+    ],
+    "Information": "Aimed at improving rehabilitation services for patients with brain injuries, spinal cord injuries, and other complex conditions. The registry collects data on demographics, rehabilitation outcomes, waiting times, and patient satisfaction. The registry supports continuous improvement in service quality and is widely used for research purposes.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2021",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktregisterforrehabiliteringsmedicin.77618.html"
+  },
+  {
+    "name": "SWEAPS – Svenska registret för avancerad barn- och ungdomskirurgi",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://sweaps.registercentrum.se/",
+    "search_tags": [
+      "surgery",
+      "SWEAPS"
+    ],
+    "Information": "Gathers comprehensive data on children requiring complex surgical interventions due to congenital malformations in the esophagus, intestines, and urinary system. It covers rare conditions like esophageal atresia and congenital diaphragmatic hernia. The goal is to enhance care quality, reduce risks, and improve long-term patient outcomes. Data collected includes patient demographics, surgical details, and long-term follow-ups from specialised centres.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2016",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Bipolär- och psykosregistret – Nationellt kvalitetsregister för bipolär sjukdom och schizofrenispektrumtillstånd",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://bipsy.registercentrum.se/",
+    "search_tags": [
+      "Schizophrenia",
+      "bipolar",
+      "psychosis"
+    ],
+    "Information": "The bipolar and psychosis registry is a national quality registry for bipolar disorder and schizophrenia spectrum conditions. It collects data on disease course, medication, treatment outcomes and care processes to support quality improvement and research in psychiatric care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2004",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/bipolarochpsykosregistretbipsy.77546.html"
+  },
+  {
+    "name": "Bättre Beroendevård",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://www.battreberoendevard.regionstockholm.se/",
+    "search_tags": [
+      "Beroendevård",
+      "addiction"
+    ],
+    "Information": "Focuses on patients receiving specialised care for substance use disorders, covering diagnoses such as alcohol, opioid, and multi-substance dependencies (ICD-10 codes F10-F19). Established to improve the quality and accessibility of addiction treatment, the registry tracks data on care plans, participation in medication-assisted programs (e.g., LARO for opioid addiction), and questions about the patient’s family situation, such as the presence of minors. The registry collaborates with healthcare units across Sweden, ensuring that treatment outcomes are monitored and used to refine addiction care strategies.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/battreberoendevard.77545.html"
+  },
+  {
+    "name": "Kvalitetsregister ECT",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://ect.rcnorr.se/",
+    "search_tags": [
+      "ECT",
+      "electroconvulsive therapy"
+    ],
+    "Information": "The ECT quality registry collects data on electroconvulsive therapy used mainly for severe psychiatric conditions such as depression. It also follows repetitive transcranial magnetic stimulation (rTMS) and supports quality monitoring and national comparison of these treatments.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2012",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterect.77560.html"
+  },
+  {
+    "name": "Q-bup – Nationellt kvalitetsregister för barn- och ungdomspsykiatri",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://qbup.registercentrum.se/",
+    "search_tags": [
+      "peadiatric care",
+      "child psychiatry",
+      "psychiatry"
+    ],
+    "Information": "Q-bup is the national quality registry for child and adolescent psychiatry. It collects data on demographics, diagnoses, treatments and outcomes to support quality improvement and more equal mental health services across Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2017",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Riksät – Nationellt kvalitetsregister för ätstörningsbehandling",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://riksat.registercentrum.se/",
+    "search_tags": [
+      "Riksät",
+      "psychiatry",
+      "eating disorder"
+    ],
+    "Information": "Riksat is a national quality registry for eating-disorder treatment. It collects information on care, treatment, outcomes and patient experience and supports quality improvement and longitudinal follow-up.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1999",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "RättspsyK – Nationellt rättspsykiatriskt kvalitetsregister",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://rattspsyk.registercentrum.se/",
+    "search_tags": [
+      "rättspsykiatriskt",
+      "RättspsyK",
+      "psychiatry"
+    ],
+    "Information": "RättspsyK is the national quality registry for forensic psychiatric care. It follows treatment plans, risk assessments, coercive measures, health status and related outcomes to support quality improvement and follow-up of compulsory forensic psychiatric care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltrattspsykiatrisktkvalitetsregisterrattspsyk.77623.html"
+  },
+  {
+    "name": "SibeR – Svenska internetbehandlingsregistret",
+    "registry_centre": [
+      "Registercentrum Västra Götaland"
+    ],
+    "url": "https://siber.registercentrum.se/",
+    "search_tags": [
+      "internetbehandlingsregistret",
+      "SibeR"
+    ],
+    "Information": "SibeR is a national quality registry for internet-delivered psychological treatment. It collects information on access to treatment, treatment processes, mental-health outcomes and completion and supports quality-driven development of digital care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2015",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskainternetbehandlingsregistretsiber.77588.html"
+  },
+  {
+    "name": "Barnnjurregistret (BNR)",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "http://barnnjurregistret.se/",
+    "search_tags": [
+      "Barnnjurregistret",
+      "BNR"
+    ],
+    "Information": "Collects data on children and adolescents with kidney diseases in Sweden. It aims to improve care quality and monitor long-term outcomes for these patients. The register includes data from all paediatric nephrology units across the country, covering several hundred individuals. Key variables include disease diagnosis, treatments, and progression.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1998",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnnjurregistret.77608.html"
+  },
+  {
+    "name": "Barnreumaregistret",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "http://barnreumaregistret.se/",
+    "search_tags": [
+      "Barnreumaregistret",
+      "reuma",
+      "rheumatic disease"
+    ],
+    "Information": "Collects data on children with paediatric rheumatic diseases in Sweden. Its main purpose is to monitor the progression of these diseases, treatments given, comorbidities, and the health and quality of life of patients. Data from patients are used to track short- and long-term effects of treatments, allowing healthcare providers to improve the quality of care. The register covers all relevant healthcare units in Sweden.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnreumaregistret.77594.html"
+  },
+  {
+    "name": "Registret för medfödda metabola sjukdomar (RMMS)",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "http://rmms.se/",
+    "search_tags": [
+      "born",
+      "RMMS"
+    ],
+    "Information": "RMMS follows people with inherited metabolic disorders. It collects data on demographics, diagnoses, treatments and outcomes to support standardised care, quality improvement and research in rare metabolic disease.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registretformedfoddametabolasjukdomarrmms.77604.html"
+  },
+  {
+    "name": "Svenska Barnhälsovårdsregistret (BHVQ)",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "http://bhvq.se/",
+    "search_tags": [
+      "child",
+      "BHVQ",
+      "Barnhälsovårdsregistret"
+    ],
+    "Information": "It collects comprehensive data on various health indicators for children, such as growth metrics, maternal mental health screenings, and language development assessments, across all child healthcare centres in Sweden. The registry includes variables such as vaccination status, parental support programs, and exposure to secondhand smoke, which are tracked from the child's first to final visits. BHVQ facilitates nationwide monitoring of child health services, supporting research and quality improvement initiatives.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "PIDcare",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "http://pidcare.se/",
+    "search_tags": [
+      "PIDcare"
+    ],
+    "Information": "The PIDcare registry focuses on individuals with primary immunodeficiencies (PID) and was established to improve care by tracking patient data, treatment outcomes, and long-term health. It collects detailed information on diagnosis, genetic findings, treatments, and immunological parameters.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2012",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforprimaraimmunbristerpidcare.77614.html"
+  },
+  {
+    "name": "Svenskt Njurregister (SNR)",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "https://www.snronline.se/",
+    "search_tags": [
+      "SNR",
+      "Njurregister",
+      "kidney"
+    ],
+    "Information": "Svenskt Njurregister follows chronic kidney disease, dialysis and kidney transplantation in Sweden. It supports clinical follow-up, quality improvement, benchmarking and research in kidney care.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1991",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktnjurregistersnr.77609.html"
+  },
+  {
+    "name": "Swespine – Svenska Ryggregistret",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "https://www.swespine.se/",
+    "search_tags": [
+      "Swespine",
+      "spine",
+      "spine disorders",
+      "Ryggregistret"
+    ],
+    "Information": "Swespine, the Swedish Spine Registry, follows spine surgery, patient characteristics, procedures and patient-reported outcomes. It supports quality assurance, comparison of treatment results and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "1998",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaryggregistretswespine.77621.html"
+  },
+  {
+    "name": "SWIBREG",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "https://www.swibreg.se/",
+    "search_tags": [
+      "Swibreg",
+      "SWIBREG",
+      "IBD"
+    ],
+    "Information": "SWIBREG is a national quality registry for inflammatory bowel disease. It follows treatment, disease activity, healthcare use and patient-reported outcomes and supports quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2013",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforinflammatorisktarmsjukdomswibreg.77586.html"
+  },
+  {
+    "name": "Svenska Palliativregistret",
+    "registry_centre": [
+      "Registercentrum Sydost"
+    ],
+    "url": "https://www.palliativregistret.se/",
+    "search_tags": [
+      "Svenska",
+      "Palliativregistret",
+      "pallitative"
+    ],
+    "Information": "Svenska Palliativregistret is a national quality registry that supports systematic improvement of end-of-life care. It collects information on care processes and outcomes and provides feedback for quality improvement and research.",
+    "category": [
+      "National quality registry"
+    ],
+    "start_date": "2005",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapalliativregistret.77633.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister akut lymfatisk leukemi",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/akut-lymfatiskt-leukemi-all/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister akut lymfatisk leukemi"
+    ],
+    "Information": "Established to support the treatment and care of patients diagnosed with this aggressive form of blood cancer, the registry collects comprehensive data on demographics, diagnosis, treatment protocols, and patient outcomes. Data variables include genetic markers, chemotherapy protocols, and remission rates, helping healthcare providers make informed decisions for better outcomes.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "1997",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutlymfatiskleukemiall.83492.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister akut myeloisk leukemi (AML), inklusive akut oklassificerad leukemi (AUL)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/hematologiskacancersjukdomar/akutmyeloiskleukemiamlinklusiveakutoklassificeradleukemiaul/kvalitetsregister.7181.html",
+    "search_tags": [
+      "Nationellt kvalitetsregister akut myeloisk leukemi (AML), inklusive akut oklassificerad leukemi (AUL)"
+    ],
+    "Information": "Focuses on collecting detailed data related to acute myeloid leukemia (AML) and acute undifferentiated leukemia (AUL) in Sweden. This national cancer quality registry collects information on patient demographics, genetic markers, treatment protocols, and outcomes, with the aim of improving the care and survival of patients with these aggressive hematologic malignancies. Includes data from diagnostic processes, chemotherapy, bone marrow transplants, and patient follow-up care. Coverage is comprehensive across Sweden, including nearly all diagnosed patients.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "1997",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutmyeloiskleukemiamlinklusiveakutoklassificeradleukemiaul.83493.html"
+  },
+  {
+    "name": "Nationellt Kvalitetsregister för Bröstcancer NKBC",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/brost/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt Kvalitetsregister för Bröstcancer NKBC"
+    ],
+    "Information": "It collects comprehensive data on breast cancer patients, covering diagnosis, treatments, and outcomes. The registry includes data on tumour characteristics, surgical interventions, radiotherapy, chemotherapy, and hormone therapies, as well as patient demographics. NKBC is crucial for improving the quality of breast cancer care across the country by enabling continuous monitoring and benchmarking of clinical practices. The registry includes nearly all diagnosed breast cancer cases in Sweden.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancernkbc.77549.html"
+  },
+  {
+    "name": "Svenska kvalitetsregistret för gynekologisk cancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/gynekologi/kvalitetsregister/",
+    "search_tags": [
+      "Svenska kvalitetsregistret för gynekologisk cancer"
+    ],
+    "Information": "A registry for gynaecological cancers, covering cancers of the ovaries, uterus, cervix, and vulva. collects detailed information on patient demographics, tumour characteristics, treatments (surgical, radiological, and chemotherapeutic), and follow-up outcomes. Its aim is to enhance the quality of care provided to women diagnosed with gynaecological cancers through systematic data collection and analysis. By monitoring treatment efficacy and patient outcomes across the country, the registry facilitates improvements in clinical practices and supports research efforts. It includes nearly all gynaecological cancer cases treated in Sweden.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakvalitetsregistretforgynekologiskcancer.77571.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister hudmelanom (SweMR)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hud-och-melanom/malignt-melanom/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister hudmelanom (SweMR)"
+    ],
+    "Information": "Focuses on tracking and improving the care and outcomes of patients diagnosed with skin melanoma. The registry collects extensive data on tumour characteristics, treatment approaches (such as surgery and immunotherapy), and patient follow-up information. Key variables include Breslow thickness, ulceration, and metastasis status, all of which are critical for prognosis. The registry covers nearly all melanoma cases diagnosed in Sweden",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2003",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterhudmelanomswemr.77580.html"
+  },
+  {
+    "name": "Svenskt kvalitetsregister för huvud- och halscancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/huvud-och-hals/kvalitetsregister/",
+    "search_tags": [
+      "Svenskt kvalitetsregister för huvud- och halscancer",
+      "throat cancer",
+      "cancer"
+    ],
+    "Information": "The registry focuses on collecting data from patients diagnosed with cancers of the oral cavity, pharynx, larynx, salivary glands, and other related areas. It gathers comprehensive data on tumour characteristics, treatment methods (such as surgery, radiotherapy, and chemotherapy), and patient outcomes. The registry is instrumental in improving the quality of care by enabling continuous monitoring of treatment effectiveness and survival rates. Covers nearly all cases of head and neck cancer in Sweden.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforhuvudochhalscancer.77581.html"
+  },
+  {
+    "name": "Svenska Hypofysregistret",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hypofys/kvalitetsregister-for-hypofystumorer/",
+    "search_tags": [
+      "Svenska Hypofysregistret",
+      "pituitary gland",
+      "cancer"
+    ],
+    "Information": "The Svenska Hypofysregistret is Sweden's national quality registry for pituitary tumours and other related conditions affecting the pituitary gland. The registry collects data on patient demographics, tumour types, treatment protocols (such as surgery, radiotherapy, and medical treatments), and long-term outcomes. It includes detailed information about hormonal imbalances caused by pituitary disorders and tracks the effects of different treatment approaches on patient recovery and quality of life. The registry covers cases from various healthcare providers across Sweden, ensuring that nearly all pituitary tumour patients are included.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2011",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahypofysregistret.77582.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
+      "KLL",
+      "CLL"
+    ],
+    "Information": "The registry aims to collect comprehensive data on patients diagnosed with CLL, including demographic information, genetic markers, treatment approaches, and patient outcomes. Key variables tracked include treatment response, disease progression, and long-term survival rates. The registry provides insights into how different therapeutic strategies affect patient outcomes and supports ongoing clinical research.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2007",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterkronisklymfatiskleukemikll.84653.html"
+  },
+  {
+    "name": "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lever-och-galla/kvalitetsregister/",
+    "search_tags": [
+      "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
+      "liver",
+      "gallbladder",
+      "cancer"
+    ],
+    "Information": "Sweden’s national quality registry for cancers of the liver, gallbladder, and bile ducts. The registry collects data on patient demographics, tumour characteristics, treatments such as surgery, chemotherapy, and radiotherapy, and long-term outcomes, including survival rates. SweLiv covers nearly all cases of liver, gallbladder, and biliary cancers treated in Sweden, providing a comprehensive dataset that helps guide clinical practice and supports research efforts to improve treatment strategies​.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforcancerilevergallblasaochgallvagarsweliv.77596.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister lymfom",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/lymfom-lymfkortelcancer/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister lymfom"
+    ],
+    "Information": "Sweden’s national quality registry for lymphoma, covering various types of lymphatic cancers such as Hodgkin's lymphoma and non-Hodgkin's lymphoma. Collects detailed data on patient demographics, tumour characteristics, treatment methods (including chemotherapy, immunotherapy, and radiation), and long-term outcomes. It provides comprehensive national coverage, capturing nearly all lymphoma cases treated in Sweden. ",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2000",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterlymfom.84684.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister myelodysplastiskt syndrom",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelodysplastiskt-syndrom-mds/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister myelodysplastiskt syndrom",
+      "blood disorder",
+      "myelodysplastic"
+    ],
+    "Information": "A quality registry for myelodysplastic syndromes, a group of blood disorders that affect the bone marrow and lead to inefficient blood cell production. Collects data on patient demographics, genetic mutations, disease subtypes, treatment protocols (such as supportive care, chemotherapy, and stem cell transplantation), and long-term outcomes. The registry covers nearly all diagnosed cases of MDS in Sweden.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelodysplastisktsyndrommds.84686.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myeloproliferativa-sjukdomar-mpn/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
+      "MPN",
+      "myeloproliferative"
+    ],
+    "Information": "This MPN registry collects data on patient demographics, disease subtypes, genetic markers (such as JAK2 mutations), treatments (including cytoreductive therapy, interferon, and bone marrow transplants), and long-term outcomes like disease progression and survival rates. Covering nearly all diagnosed cases in Sweden, this registry provides valuable insights for standardising treatment protocols and enhancing patient care.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyeloproliferativasjukdomarmpn.84687.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för mastocytos",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/hematologiskacancersjukdomar/mastocytos/kvalitetsregister.11775.html",
+    "search_tags": [
+      "mastocytos",
+      "mastocytosis",
+      "Nationellt kvalitetsregister för mastocytos"
+    ],
+    "Information": "The Swedish National Quality Registry for Mastocytosis collects structured data on patients with mastocytosis to support quality improvement, follow-up and research. The registry is part of the Swedish national cancer quality registry system and is supported by Regionala cancercentrum i samverkan.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2016",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister myelom",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/myelom/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister myelom",
+      "myeloma"
+    ],
+    "Information": "Sweden’s national quality registry for multiple myeloma, a cancer of plasma cells. Collects comprehensive data on patients with myeloma, including patient demographics, genetic markers, disease stage, and treatment regimens such as chemotherapy, immunotherapy, and stem cell transplantation. ",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2008",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelom.84688.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/neuroendokrinabuktumorer/kvalitetsregister.3525.html",
+    "search_tags": [
+      "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
+      "GEP-NET"
+    ],
+    "Information": "The registry collects extensive data on patient demographics, tumour characteristics, genetic markers, treatments (such as surgery, targeted therapies, and peptide receptor radionuclide therapy), and patient outcomes like survival rates and tumour progression. GEP-NET provides nearly complete coverage of cases in Sweden.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2010",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Regionalt kvalitetsregister för skelettmetastaser",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/overgripande-kunskapsstod/skelettmetastaser/",
+    "search_tags": [
+      "Regionalt kvalitetsregister för skelettmetastaser",
+      "bone metastases",
+      "cancer"
+    ],
+    "Information": "Focuses on bone metastases and collects data on cancer type, treatment approaches (such as radiotherapy, surgery, or medication to strengthen bones), and patient outcomes like pain relief, mobility, and survival. The registry covers nearly all cases of skeletal metastases treated in Sweden, making it an essential tool for improving patient care and treatment strategies.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2009",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister sköldkörtelcancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/skoldkortel/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister sköldkörtelcancer",
+      "thyroid cancer",
+      "thyroid"
+    ],
+    "Information": "Sweden’s national quality registry for thyroid cancer, established to monitor and improve the care and outcomes for patients diagnosed with this type of cancer. The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, radioactive iodine therapy, and hormone replacement), and patient outcomes, including survival rates and recurrence.",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2003",
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforskoldkortelcancer.77625.html"
+  },
+  {
+    "name": "Svenskt kvalitetsregister för koloskopier och kolorektalcancerscreening (SveReKKS)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/Screening-tjock-och-andtarmscancer/sverekks/",
+    "search_tags": [
+      "SveReKKS - kvalitetsregister"
+    ],
+    "Information": "Focuses on colorectal cancer screening and prevention. Collects detailed data on screening participation rates, diagnostic results, follow-up procedures, and treatment outcomes. This registry supports Sweden’s organised colorectal cancer screening program, aimed at early detection and treatment of precancerous lesions and cancer in the colon and rectum. ",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "start_date": "2017",
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för analcancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/anal/kvalitetsregister.3263.html",
+    "search_tags": [
+      "Nationellt kvalitetsregister för analcancer"
+    ],
+    "Information": "Sweden’s national quality registry for anal cancer. It was established to improve the diagnosis, treatment, and outcomes of patients with this relatively rare form of cancer. The registry collects data on patient demographics, tumour characteristics, treatment methods (such as chemotherapy, radiotherapy, and surgery), and long-term patient outcomes, including survival rates and recurrence.",
+    "start_date": "2015",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för barncancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/barn/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för barncancer",
+      "peadiatric cancer",
+      "cancer"
+    ],
+    "Information": "Established to improve the care and outcomes for children diagnosed with cancer, it gathers detailed information on patient demographics, cancer types, treatment protocols (such as chemotherapy, radiotherapy, and surgery), and long-term outcomes. The registry covers nearly all cases of paediatric cancer across Sweden, tracking patient survival rates, treatment effectiveness, and any late effects of therapy.",
+    "start_date": "2011",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarncancerregistretsbcr.77539.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/bukspottkortel/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
+      "pancreatic cancer"
+    ],
+    "Information": "The registry collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment modalities (such as surgery, chemotherapy, and radiotherapy), and long-term outcomes, including survival rates. Covers nearly all pancreatic cancer cases in Sweden.​",
+    "start_date": "2011",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbukspottkortelcancerpankreasregistret.77552.html"
+  },
+  {
+    "name": "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/gynekologisk-cellprovskontroll/kvalitetsregister/",
+    "search_tags": [
+      "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)"
+    ],
+    "Information": "Includes data on screening, diagnosis, and treatment for cervical cancer across Sweden. It collects information on screening participation, follow-up procedures, and patient outcomes to monitor and improve the effectiveness of the national cervical cancer screening program. The registry covers nearly all eligible women in Sweden who participate in routine screening.",
+    "start_date": "1999",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistretforcervixcancerpreventionnkcx.77597.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/hjarna-ryggmarg-och-hypofys/hjarna-och-ryggmarg/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
+      "CNS",
+      "brain tumour"
+    ],
+    "Information": "Sweden's national quality registry for brain tumours and central nervous system (CNS) cancers. t collects comprehensive data on patient demographics, tumour characteristics, genetic markers, treatment methods (such as surgery, radiotherapy, and chemotherapy), and long-term outcomes like survival rates and neurological function.",
+    "start_date": "2009",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhjarntumorerochcentralanervsystemet.77575.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för KML (kronisk myeloisk leukemi)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-myeloisk-leukemi-kml/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för KML",
+      "chronic myeloid leukemia",
+      "KML",
+      "CML"
+    ],
+    "Information": "Collects detailed data on patients diagnosed with this specific type of leukemia, tracking treatment methods (such as tyrosine kinase inhibitors), disease progression, and long-term patient outcomes, including survival rates and quality of life. It covers most patients diagnosed with KML in the country. ",
+    "start_date": "2002",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkroniskmyeloiskleukemikml.84685.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för lungcancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/lunga-och-lungsack/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för lungcancer",
+      "lung cancer"
+    ],
+    "Information": "It collects comprehensive data on patient demographics, tumour characteristics, diagnostic procedures, treatment approaches (such as surgery, radiotherapy, chemotherapy, and immunotherapy), and long-term outcomes, including survival rates. Covers almost all lung cancer cases in Sweden.",
+    "start_date": "2002",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlungcancer.77599.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/matstrupe-och-magsack/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
+      "gastric cancers",
+      "cancer"
+    ],
+    "Information": "Sweden’s national quality registry for oesophageal and gastric cancers. It collects detailed data on patient demographics, tumour characteristics, diagnostic procedures, treatment modalities (including surgery, chemotherapy, and radiotherapy), and patient outcomes such as survival rates and post-treatment quality of life.",
+    "start_date": "2007",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterformatstrupsochmagsackscancernrev.77553.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för njurcancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/njure/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för njurcancer",
+      "kidney cancer"
+    ],
+    "Information": "The registry tracks patient demographics, tumour characteristics, treatment modalities (such as surgery, targeted therapies, and immunotherapies), and long-term outcomes, including survival rates and quality of life. By covering nearly all kidney cancer cases in Sweden, the registry plays a crucial role in improving treatment standards, facilitating clinical research, and informing national guidelines for managing kidney cancer​.",
+    "start_date": "2005",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfornjurcancer.77607.html"
+  },
+  {
+    "name": "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/prostatacancertestning/kvalitetsregister.7547.html",
+    "search_tags": [
+      "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
+      "prostate cancer",
+      "prostate"
+    ],
+    "Information": "The registry gathers comprehensive data on screening participation, test results (such as PSA levels), diagnostic procedures, and follow-up treatments, ensuring consistency and quality in prostate cancer testing across Sweden.",
+    "start_date": "2023",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för sarkom",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/sarkom/skelettochmjukdelssarkom/kvalitetsregister.3495.html",
+    "search_tags": [
+      "Nationellt kvalitetsregister för sarkom",
+      "ewings sarcoma",
+      "sarcoma"
+    ],
+    "Information": "The registry aims to improve the diagnosis, treatment, and outcomes for patients with various forms of sarcoma, including osteosarcoma, Ewing’s sarcoma, and soft tissue sarcomas. It collects data on patient demographics, tumour characteristics, surgical interventions, chemotherapy, and radiotherapy treatments, as well as long-term outcomes such as recurrence rates and survival.",
+    "start_date": "2009",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för testikelcancer seminom",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/testikel/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för testikelcancer seminom",
+      "prostate cancer"
+    ],
+    "Information": "The registry aims to improve the quality of care by allowing clinics and regions to compare their data with national statistics, providing insights into survival rates, tumour stages, and treatment effectiveness. It also facilitates research, including biobanking initiatives, by providing information on biological samples",
+    "start_date": "2000",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfortestikelcancerseminom.77630.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/tjocktarm-andtarm-och-anal/tjock--och-andtarm/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
+      "colorectal cancer"
+    ],
+    "Information": "The national colorectal cancer registry collects data on diagnosis, surgical treatment, radiotherapy, chemotherapy and outcomes. It supports comparison across hospitals and regions, quality improvement and research in colorectal cancer care.",
+    "start_date": "2007",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakolorektalcancerregistretscrcr.77631.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för urinblåsecancer",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/urinblasa-urinvagar/kvalitetsregister/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för urinblåsecancer",
+      "bladder cancer"
+    ],
+    "Information": "The national bladder cancer registry collects information on tumour stage and grade, treatment such as surgery, radiotherapy, chemotherapy or immunotherapy, and long-term outcomes. It supports uniform quality standards, clinical follow-up and research.",
+    "start_date": "1997",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforurinblasecancer.77554.html"
+  },
+  {
+    "name": "Nationella prostatacancerregistret (NPCR)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://npcr.se/",
+    "search_tags": [
+      "Nationellt kvalitetsregister för prostatacancer",
+      "prostate cancer"
+    ],
+    "Information": "NPCR collects comprehensive data on diagnostic procedures, disease characteristics, treatment, and outcomes for all men diagnosed with prostate cancer in Sweden. Established to support quality improvement and clinical research, NPCR enables benchmarking across healthcare providers and contributes to evidence-based care.",
+    "start_date": "1987",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaprostatacancerregistretnpcr.77615.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister peniscancer (NPECR)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/penis/kvalitetsregister.3518.html",
+    "search_tags": [
+      "Nationellt kvalitetsregister för peniscancer",
+      "penis cancer"
+    ],
+    "Information": "The national penile cancer registry includes newly diagnosed invasive and non-invasive penile cancer and records information on diagnosis, staging, treatment, waiting times and follow-up. It also supports patient-reported outcome and experience measures.",
+    "start_date": "2000",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforpeniscancer.77613.html"
+  },
+  {
+    "name": "Nationellt kvalitetsregister för mammografiscreening (NKM)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/brostcancerscreening/kvalitetsregister",
+    "search_tags": [
+      "Nationellt kvalitetsregister för mammografiscreening",
+      "breast cancer screening"
+    ],
+    "Information": "NKM monitors the entire breast cancer screening process in Sweden, covering invitation, participation, imaging results, and diagnostic follow-up. Targeting women aged 40–74, the registry also includes referred patients of all ages undergoing breast radiology.",
+    "start_date": "about 2020",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11",
+    "metadata_source": "SKR",
+    "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancerscreeningnkb.77602.html"
+  },
+  {
+    "name": "Nationellt onkogenetiskt kvalitetsregister (NOGA)",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/preventiontidigupptackt/arftligcancer/kvalitetsregisterforarftligcancernoga.7556.html",
+    "search_tags": [
+      "Nationellt onkogenetiskt kvalitetsregister (NOGA)"
+    ],
+    "Information": "The National Oncogenetic Quality Registry (NOGA) collects data on individuals undergoing genetic evaluation for hereditary cancer. Its aim is to improve and standardize care across Sweden by monitoring diagnostic lead times, adherence to clinical guidelines, and outcomes. The registry also supports research and quality improvement in hereditary cancer care.",
+    "start_date": "2021",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11"
+  },
+  {
+    "name": "Register för cancerläkemedel",
+    "registry_centre": [
+      "Regionala Cancercentrum i Samverkan"
+    ],
+    "url": "https://cancercentrum.se/diagnosbehandling/cancerlakemedel/registerforcancerlakemedel.7318.html",
+    "search_tags": [
+      "Register för cancerläkemedel",
+      "cancer drugs",
+      "cancer",
+      "läkemedel"
+    ],
+    "Information": "The Cancer Drug Registry monitors the use of selected cancer medications across Sweden. It consists of 17 regional and one interregional registry, aiming to track treatment patterns, ensure equitable access, and support clinical decision-making. Annual reports provide insights into national trends and regional variations in cancer drug usage.",
+    "start_date": "2018",
+    "category": [
+      "National cancer quality registry"
+    ],
+    "last_verified": "2026-08-11"
+  }
 ]

--- a/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
+++ b/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
@@ -11,11 +11,14 @@
             "Sverige",
             "obesity"
         ],
-        "Information": "One of the world's largest and oldest registries for the treatment of childhood obesity. BORIS was established in 2005 and has over 40,000 registered individuals. In more than 40 scientific publications, BORIS has contributed to increased knowledge about childhood obesity.",
+        "Information": "BORIS is one of the world's largest and oldest registries for the treatment of childhood obesity. It supports quality improvement and research by collecting data on treatment and outcomes in paediatric obesity care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2005"
+        "start_date": "2005",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/barnobesitasregistretisverigeboris.77541.html"
     },
     {
         "name": "Endovaskulär behandling av Stroke – EVAS-registret",
@@ -33,7 +36,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2012"
+        "start_date": "2012",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/endovaskularbehandlingavstrokeevasregistret.77562.html"
     },
     {
         "name": "Graviditetsregistret",
@@ -49,11 +55,14 @@
             "fetal",
             "neonatal"
         ],
-        "Information": "The purpose of the registry is to provide a solid foundation of data and results for healthcare services across the country. Data is collected from maternal healthcare, fetal diagnostics and delivery records. As of 2024, the registry includes data on roughly 58,500 pregnant individuals and about 63,600 deliveries.",
+        "Information": "The Pregnancy Register provides a national foundation of data for maternal and perinatal healthcare. It collects information from maternal healthcare, fetal diagnostics and delivery records to support quality improvement, follow-up and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/graviditetsregistret.77568.html"
     },
     {
         "name": "InfCareHIV",
@@ -67,29 +76,35 @@
             "immune",
             "virus"
         ],
-        "Information": "Includes all HIV clinics in Sweden, covering over 99% of those diagnosed with HIV. Key data collected at enrollment and follow-up include sex at birth, gender identity, transmission route, HIV RNA levels, CD4+ cell counts, drug resistance, and co-infections with hepatitis C and B. Medication start/stop dates, AIDS diagnoses, and causes of death are also recorded.",
+        "Information": "InfCareHIV is a national quality registry that collects longitudinal clinical, laboratory and treatment data for people living with HIV in Sweden. It supports clinical follow-up, quality improvement and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1983"
+        "start_date": "1983",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehiv.77574.html"
     },
     {
         "name": "InfCareHepatit",
         "registry_centre": [
             "Kvalitetsregistercentrum Stockholm"
         ],
-        "url": "http://www.infcarehepatit.se/",
+        "url": "https://www.infcarehepatit.se/",
         "search_tags": [
             "liver",
             "hepatitis",
             "virus",
             "InfCareHepatit"
         ],
-        "Information": "InfCareHepatit is a Swedish registry that includes individuals with Hepatitis B and C. It involves all infectious disease clinics in Sweden and one gastroenterology clinic, covering over 90% of Hepatitis C patients and a majority of those with Hepatitis B. The registry collects data on age, gender at birth, country of birth, virus type, viral load, transmission route, date of first positive Hepatitis B or C test, liver function tests, and fibrosis assessment results. For those receiving treatment, it also records medication type, treatment outcomes, and any complications such as liver cirrhosis or cancer.",
+        "Information": "InfCareHepatit is a national quality registry for hepatitis B and C in Sweden. It collects longitudinal clinical, laboratory and treatment data to support quality improvement, follow-up and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/infcarehepatit.77573.html"
     },
     {
         "name": "Kvalitetsregister för cystisk fibros – CF-registret",
@@ -106,7 +121,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2012"
+        "start_date": "2012",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterforcystiskfibroscfregistret.77556.html"
     },
     {
         "name": "Nationellt kvalitetsregister för assisterad befruktning – Q-IVF",
@@ -123,7 +141,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforassisteradbefruktningqivf.77538.html"
     },
     {
         "name": "Svenska hemofiliregistret",
@@ -141,7 +162,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2015"
+        "start_date": "2015",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaregistretforblodningssjukdomar.77548.html"
     },
     {
         "name": "Svenska Intensivvårdsregistret – SIR",
@@ -159,7 +183,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaintensivvardsregistretsir.77587.html"
     },
     {
         "name": "Svenska korsbandsregistret",
@@ -175,7 +202,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2005-05-01"
+        "start_date": "2005-05-01",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskkorsbandsregister.77591.html"
     },
     {
         "name": "Svenska neuroregister",
@@ -193,7 +223,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2001"
+        "start_date": "2001",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaneuroregister.77606.html"
     },
     {
         "name": "Svensk Reumatologis Kvalitetsregister – SRQ",
@@ -210,7 +243,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1995"
+        "start_date": "1995",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskreumatologiskvalitetsregistersrq.77620.html"
     },
     {
         "name": "Svenskt neonatalt kvalitetsregister – SNQ",
@@ -228,7 +264,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2001"
+        "start_date": "2001",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktneonataltkvalitetsregistersnq.77605.html"
     },
     {
         "name": "InfCare Sprututbyte",
@@ -246,7 +285,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2016"
+        "start_date": "2016",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt register för levertransplantation",
@@ -262,7 +302,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "1998"
+        "start_date": "1998",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Lungfibrosregistret",
@@ -280,7 +321,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2014"
+        "start_date": "2014",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Svenskt kvalitetsregister för atopiskt dermatit – SwedAD",
@@ -294,11 +336,12 @@
             "eczema",
             "atopic dermatitis"
         ],
-        "Information": "SwedAD collects detailed data on patients with atopic dermatitis, including demographic information, disease severity, treatment regimens, and patient-reported outcomes such as quality of life and symptom control. It also includes information on healthcare resource utilisation, like hospital visits and medications. It includes data from both specialised care centres and general practitioners.",
+        "Information": "SwedAD is a national quality registry for atopic dermatitis. It supports follow-up of disease severity, treatment and patient-reported outcomes and is used for quality improvement and research.",
         "category": [
-            "Other quality registry"
+            "National quality registry"
         ],
-        "start_date": "2019"
+        "start_date": "2019",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Amputations- och Protesregistret Swedeamp",
@@ -316,7 +359,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/amputationsochprotesregisterswedeamp.77535.html"
     },
     {
         "name": "Barnkataraktregistret PECARE",
@@ -334,7 +380,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2006"
+        "start_date": "2006",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "BPSD – Svenskt register för Beteendemässiga och Psykiska Symptom vid Demens",
@@ -352,7 +399,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforbeteendemassigaochpsykiskasymtomviddemenssjukdombpsd.77557.html"
     },
     {
         "name": "CPUP – Uppföljningsprogram för Cerebral Pares",
@@ -370,7 +420,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/cerebralparesuppfoljningsprogramcpup.77555.html"
     },
     {
         "name": "HAKIR – Handkirurgiskt kvalitetsregister",
@@ -388,7 +441,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/handkirurgisktkvalitetsregisterhakir.77572.html"
     },
     {
         "name": "Könsdysforiregistret",
@@ -406,7 +462,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2017"
+        "start_date": "2017",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "LKG-registret – Nationellt kvalitetsregister för läpp- käk- och/eller gomspalt",
@@ -423,24 +480,30 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlappkakochgomspaltlkgregistret.77600.html"
     },
     {
         "name": "MMCUP – Kvalitetsregister för MMC (myelomeningocele) och annan neuralrörsdefekt",
         "registry_centre": [
             "Registercentrum Syd"
         ],
-        "url": "http://mmcup.se/",
+        "url": "https://mmcup.se/",
         "search_tags": [
             "MMCUP",
             "myelomeningocele",
             "neural tube defect"
         ],
-        "Information": "This registry collects data on patients with myelomeningocele (spina bifida) and other neural tube defects. It includes information on surgical interventions, neurological function, urological and orthopaedic outcomes, associated conditions, and patient-reported outcomes related to quality of life. It captures data on approximately 95% of all cases in Sweden.",
+        "Information": "MMCUP is a follow-up programme and quality registry for people with myelomeningocele and related conditions. It supports systematic follow-up of function, interventions, complications and outcomes across Sweden.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterformmcannanneuralrorsdefektochhydrocefalusmmcup.77622.html"
     },
     {
         "name": "Nationella Kataraktregistret",
@@ -453,11 +516,14 @@
             "vision",
             "cataract"
         ],
-        "Information": "The register gathers comprehensive data on cataract surgeries performed in Sweden, including patient demographics, types of cataract, surgical techniques, intraocular lenses used, complications, and visual outcomes. This registry covers over 99% of all cataract surgeries in Sweden, including data from all ophthalmology clinics and hospitals performing these procedures.",
+        "Information": "The National Cataract Register gathers data on cataract surgery in Sweden, including patient characteristics, surgical techniques, intraocular lenses, complications and visual outcomes. It supports quality monitoring, comparison between units and research in ophthalmic surgery.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1992"
+        "start_date": "1992",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakataraktregistret.77569.html"
     },
     {
         "name": "Nationella Kvalitetsregistret för Infektionssjukdomar",
@@ -475,25 +541,29 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "RIKSHÖFT",
         "registry_centre": [
             "Registercentrum Syd"
         ],
-        "url": "http://rikshoft.se/",
+        "url": "https://rcsyd.se/rikshoft/",
         "search_tags": [
             "RIKSHÖFT",
             "fracture",
             "hip",
             "bone"
         ],
-        "Information": "Gathers data on patients with hip fractures, including demographic details, fracture types, treatments (surgical and non-surgical), complications, rehabilitation, and functional outcomes such as mobility and pain. It covers nearly all hospitals in Sweden that treat hip fractures, with around 90% of cases included in the registry.",
+        "Information": "RIKSHOFT follows hip-fracture care and outcomes in Sweden to support comparison, quality improvement and research across the care pathway.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1988"
+        "start_date": "1988",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhoftfrakturrikshoft.77583.html"
     },
     {
         "name": "SKaPa – Svenskt kvalitetsregister för Karies och Parodontit",
@@ -511,7 +581,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforkariesochparodontitskapa.77589.html"
     },
     {
         "name": "SKRS – Svenskt Kvalitetsregister för Rehabilitering vid Synnedsättning",
@@ -528,7 +601,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2015"
+        "start_date": "2015",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforrehabiliteringvidsynnedsattningskrs.77619.html"
     },
     {
         "name": "SQRTPA – Scandinavian Quality Register for Thyroid, Parathyroid and Adrenal surgery",
@@ -546,7 +622,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2004"
+        "start_date": "2004",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianqualityregisterforthyroidparathyroidandadrenalsurgerysqrtpa.77561.html"
     },
     {
         "name": "Svenska Cornearegistret",
@@ -564,7 +643,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1996"
+        "start_date": "1996",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskacornearegistret.77579.html"
     },
     {
         "name": "Svenska Nationella Fotledsregistret",
@@ -582,7 +664,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1997"
+        "start_date": "1997",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskanationellafotledsregistret.77563.html"
     },
     {
         "name": "Svenska Makularegistret",
@@ -600,7 +685,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskamakularegistret.77601.html"
     },
     {
         "name": "Svenska Skulder- och Armbågsregistret",
@@ -617,7 +705,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1999"
+        "start_date": "1999",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaskulderocharmbagsregistret.77624.html"
     },
     {
         "name": "SweTrau – Svenska Traumaregistret",
@@ -635,7 +726,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskatraumaregistret.77632.html"
     },
     {
         "name": "AmbuReg – Ambulansregistret",
@@ -649,11 +743,12 @@
             "ambulance",
             "emergency"
         ],
-        "Information": "AmbuReg collects data on pre-hospital care provided by ambulance services in Sweden. This includes information on patient demographics, medical conditions, types of interventions performed, response times, and outcomes of pre-hospital treatment.",
+        "Information": "AmbuReg is the national quality registry for ambulance care in Sweden. It supports quality improvement, follow-up and comparison of prehospital emergency care.",
         "category": [
-            "Other quality registry"
+            "National quality registry"
         ],
-        "start_date": "2016"
+        "start_date": "2016",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Analfistelregistret",
@@ -671,7 +766,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "GamReg Sweden – Kvalitetsregister för spel- och dataspelsberoende",
@@ -689,7 +785,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2019"
+        "start_date": "2019",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Glaukomregistret",
@@ -707,25 +804,27 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "LHON-registret – Registret för Lebers Hereditära Opticusneuropati",
         "registry_centre": [
             "Registercentrum Syd"
         ],
-        "url": "https://lhon-registret.se/om-lhon/",
+        "url": "https://lhon-registret.se/",
         "search_tags": [
             "optic",
             "Lebers",
             "Leber's hereditary optic neuropathy",
             "LHON-registret"
         ],
-        "Information": "Data from the registry may be used to try to identify the risk of developing vision impairment. Since the registry not only includes individuals with vision impairment but also carriers of the genetic variants who have normal vision, the registry may eventually be used to identify environmental or lifestyle factors that preceded vision impairment.",
+        "Information": "The Swedish LHON Registry is currently a research registry for Leber hereditary optic neuropathy (LHON). Its primary purpose is to facilitate research projects and improve knowledge about the condition.",
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2018"
+        "start_date": "2018",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "LSR – Lund Stroke Register",
@@ -743,7 +842,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2001"
+        "start_date": "2001",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Njurtransplantationsregistret",
@@ -761,7 +861,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Barnkirurgi operationsregister",
@@ -777,7 +878,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Register för brachyterapi vid uvealt melanom",
@@ -795,7 +897,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Sklerodermiregistret",
@@ -813,7 +916,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Svenska Lambåregistret",
@@ -829,7 +933,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "SweAAA – Svenskt Register för Abdominellt Aortaaneurysm",
@@ -846,23 +951,30 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11"
     },
     {
-        "name": "Sällsynta diagnoser",
+        "name": "RaraSwed – Nationellt kvalitetsregister för sällsynta hälsotillstånd",
         "registry_centre": [
             "Registercentrum Syd"
         ],
-        "url": "https://rcsyd.se/anslutna-register",
+        "url": "https://sodrasjukvardsregionen.se/csd-syd/raraswed-kvalitetsregister/",
         "search_tags": [
+            "RaraSwed",
             "rare disease",
-            "genetic"
+            "genetic",
+            "Sällsynta diagnoser",
+            "sällsynta hälsotillstånd"
         ],
-        "Information": "Collects data on rare diseases, focusing on diagnosis and treatment outcomes.",
+        "Information": "RaraSwed is the Swedish national quality registry for rare health conditions. It collects structured information across rare diagnoses to support quality improvement, follow-up and research and to improve knowledge about healthcare and outcomes for people living with rare conditions.",
         "category": [
-            "Other quality registry"
+            "National quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "verification_source": "Official registry source",
+        "verification_url": "https://rcsyd.se/anslutna-register/raraswed-nationellt-kvalitetsregister-for-sallsynta-diagnoser",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "PsoReg – Nationellt register för systembehandling av psoriasis",
@@ -880,7 +992,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2006"
+        "start_date": "2006",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registerforsystembehandlingavpsoriasispsoreg.77616.html"
     },
     {
         "name": "Riksstroke – Nationellt kvalitetsregister för strokesjukvård",
@@ -898,7 +1013,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1994"
+        "start_date": "1994",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellakvalitetsregistretforstrokeriksstroke.77627.html"
     },
     {
         "name": "Svenskt Bråckregister  – Nationellt kvalitetsregister inom bråckkirurgi",
@@ -913,7 +1031,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1992"
+        "start_date": "1992",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktbrackregister.77598.html"
     },
     {
         "name": "GynOp – Nationella kvalitetsregister inom gynekologisk kirurgi",
@@ -930,7 +1051,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterinomgynekologiskkirurgigynop.77570.html"
     },
     {
         "name": "SveATTR – Svenska transtyretinamyloidosregistret",
@@ -946,14 +1070,15 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2019"
+        "start_date": "2019",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "DBS – Kvalitetsregister inom deep brain stimulation",
         "registry_centre": [
             "Registercentrum Norr"
         ],
-        "url": "https://deepbrainstimulation.se/",
+        "url": "https://rcnorr.se/anslutna-register/",
         "search_tags": [
             "DBS",
             "stimulation",
@@ -963,7 +1088,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "CKG – Kardiovaskulär genetik",
@@ -981,7 +1107,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "Unknown"
+        "start_date": "Unknown",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Terapeutisk aferes – Internationellt register för terapeutisk aferes behandling",
@@ -996,7 +1123,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "1992"
+        "start_date": "1992",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "AURICULA – Nationellt register för förmaksflimmer och antikoagulation",
@@ -1012,7 +1140,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "GallRiks – Svenskt kvalitetsregister för gallstenskirurgi",
@@ -1025,11 +1154,14 @@
             "cholecystectomy",
             "gallstone surgery"
         ],
-        "Information": "GallRiks monitors gallstone surgeries in Sweden, collecting data on over 12,000 gallbladder surgeries and 6,000 endoscopic procedures annually. It tracks complications, surgery types, and patient outcomes, aiming to reduce post-operative complications, which occur in 5-10% of cases. GallRiks covers all hospitals performing gallstone surgery, ensuring comprehensive national data​.",
+        "Information": "GallRiks is Sweden's national quality registry for gallstone surgery and ERCP. It records gallbladder surgery, ERCP procedures and postoperative complications and supports quality monitoring, comparison between units and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2005"
+        "start_date": "2005",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforgallstenskirurgiochercpgallriks.77567.html"
     },
     {
         "name": "Kateterablationsregistret – Nationellt kvalitetsregister för kateterablation vid hjärtrusningar",
@@ -1045,7 +1177,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2004"
+        "start_date": "2004",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkateterablation.77544.html"
     },
     {
         "name": "NRS – Nationellt register över smärtrehabilitering",
@@ -1061,7 +1196,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisteroversmartrehabiliteringnrs.77626.html"
     },
     {
         "name": "RiksSvikt – Nationellt kvalitetsregister för hjärtsvikt",
@@ -1073,11 +1211,14 @@
             "RiksSvikt",
             "hear disease"
         ],
-        "Information": "RiksSvikt collects data on patients with heart failure, focusing on diagnostics, treatments, and long-term outcomes. It aims to ensure that 90% of patients are treated according to national guidelines, covering most hospitals across Sweden.",
+        "Information": "RiksSvikt is a national quality registry for heart failure. It collects data on diagnostics, treatment and long-term outcomes to support guideline-based care, quality improvement and research across Swedish hospitals.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2003"
+        "start_date": "2003",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellthjartsviktsregisterrikssvikt.77578.html"
     },
     {
         "name": "RiksSår – Nationellt kvalitetsregister för svårläkta sår",
@@ -1094,7 +1235,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforpatientermedsvarlaktasarrikssar.77628.html"
     },
     {
         "name": "Senior alert – Nationellt kvalitetsregister för vård och omsorg",
@@ -1107,32 +1251,38 @@
             "senior alert",
             "treatment"
         ],
-        "Information": "Senior alert monitors the care of over 500,000 elderly patients annually. It tracks risks like falls, malnutrition, and pressure ulcers, with national coverage in elderly care facilities, hospitals, and home care​.",
+        "Information": "Senior alert is a national quality registry and a tool for preventive care. It supports systematic prevention and follow-up of risks including falls, pressure ulcers, malnutrition, poor oral health and bladder dysfunction.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforvardochomsorgsenioralert.77634.html"
     },
     {
         "name": "SOReg – Scandinavian Obesity Surgery Registry",
         "registry_centre": [
             "Uppsala Clinical Research Center"
         ],
-        "url": "https://www.ucr.uu.se/soreg/",
+        "url": "https://www.soreg.se/",
         "search_tags": [
             "Obesity",
             "Scandinavian",
             "Surgery",
             "SOReg"
         ],
-        "Information": "SOReg collects data from approximately 7,000 patients annually undergoing bariatric surgery in Sweden. It monitors surgical types, complications, and long-term outcomes, covering all bariatric surgery centres in Sweden.",
+        "Information": "SOReg is a quality registry for bariatric surgery. It follows procedures, complications, weight outcomes and long-term follow-up and supports quality improvement and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/scandinavianobesitysurgeryregistersoreg.77611.html"
     },
     {
-        "name": "SPAHR – Svenska PAH & CTEPH registret",
+        "name": "SPAHR – Svenska PAH och CTEPH-registret",
         "registry_centre": [
             "Uppsala Clinical Research Center"
         ],
@@ -1142,29 +1292,35 @@
             "CTEPH",
             "SPAHR"
         ],
-        "Information": "Includes about 500 patients diagnosed with pulmonary arterial hypertension (PAH) and chronic thromboembolic pulmonary hypertension (CTEPH) in Sweden. It focuses on tracking diagnosis, treatments, and outcomes​.",
+        "Information": "SPAHR is a national quality registry for pulmonary arterial hypertension (PAH) and chronic thromboembolic pulmonary hypertension (CTEPH). It follows diagnosis, treatment, function, quality of life and prognosis and supports national comparison, quality improvement and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapahochctephregistretspahr.77584.html"
     },
     {
         "name": "SPOR – Svenskt perioperativt register",
         "registry_centre": [
             "Uppsala Clinical Research Center"
         ],
-        "url": "https://www.ucr.uu.se/spor/",
+        "url": "https://spor.se/",
         "search_tags": [
             "register",
             "SPOR",
             "UCR",
             "perioperativt"
         ],
-        "Information": "SPOR collects perioperative data from over 1.2 million surgeries annually in Sweden, focusing on anaesthesia and post-surgical recovery. The registry helps improve patient safety in surgical care across Swedish hospitals​.",
+        "Information": "SPOR is a national quality registry that collects perioperative data for patients undergoing surgery. It supports patient safety, quality improvement, national comparison and research across perioperative care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktperioperativtregisterspor.77610.html"
     },
     {
         "name": "SveDem – Svenska registret för kognitiva sjukdomar/demenssjukdomar",
@@ -1178,11 +1334,14 @@
             "UCR",
             "SveDem"
         ],
-        "Information": "SveDem tracks more than 90,000 patients with dementia, collecting data on cognitive evaluations, treatments, and long-term care plans. It includes primary care and memory clinics across Sweden​.",
+        "Information": "SveDem, the Swedish Registry for Cognitive/Dementia Disorders, supports systematic follow-up of diagnosis, treatment, care and support for people with cognitive disorders. It is used for quality improvement, national follow-up and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforkognitivasjukdomardemenssjukdomarsvedem.77558.html"
     },
     {
         "name": "SWEDCON – Barnhjärtregistret (inkluderar GUCH, det vill säga vuxna med medfött hjärtfel)",
@@ -1200,7 +1359,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1998"
+        "start_date": "1998",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterformedfoddahjartsjukdomarswedcon.77603.html"
     },
     {
         "name": "SWEDEHEART – Sammanslagning av RIKS-HIA, SEPHIA, SCAAR, TAVI, Svenska Hjärtkirurgiregistret och Kardiogenetikregistret.",
@@ -1218,7 +1380,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforhjartintensivvardkranskarlsrontgenpcihjartkirurgiochsekundarpreventionswedeheart.77576.html"
     },
     {
         "name": "SWEDEVOX – Andningssviktregistret över oxygenbehandling och respiratorbehandling i hemmet",
@@ -1235,7 +1400,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/andningssviktsregistretswedevox.77536.html"
     },
     {
         "name": "SWEDVASC – Nationellt register för kärlkirurgi",
@@ -1247,11 +1415,14 @@
             "vain",
             "SWEDVASC"
         ],
-        "Information": "SWEDVASC includes more than 100,000 vascular surgery cases. It tracks procedures like aneurysm repairs and peripheral artery disease treatment from hospitals across Sweden​.",
+        "Information": "SWEDVASC is the national quality registry for vascular surgery. It follows procedures such as aneurysm repair and treatment of peripheral artery disease and supports quality improvement, comparison and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1994"
+        "start_date": "1994",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkarlkirurgiswedvasc.77592.html"
     },
     {
         "name": "SVAR – Svenskt akutvårdsregister",
@@ -1264,11 +1435,12 @@
             "SVAR",
             "acute care"
         ],
-        "Information": "SVAR is a national registry designed to cover the entire emergency care process, including prehospital care, emergency departments, and acute wards. It currently tracks over 600,000 patient visits annually and aims to improve the quality of emergency care across Sweden. Data is automatically collected from patient records to ensure high coverage and reliability​.",
+        "Information": "SVAR is a national registry covering the emergency care pathway, including prehospital care, emergency departments and acute wards. It supports quality improvement and follow-up of emergency care across Sweden.",
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "TBI – Traumatic Brain Injury",
@@ -1286,7 +1458,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "ThoR – Allmän Thoraxkirurgi",
@@ -1303,7 +1476,8 @@
         "category": [
             "Other quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "BRIMP – Bröstimplantatregistret",
@@ -1316,11 +1490,14 @@
             "Bröstimplantatregistret",
             "BRIMP"
         ],
-        "Information": "BRIMP collects data on all breast implant procedures, including both cosmetic and reconstructive surgeries. It tracks implant types, surgical methods, and complications, aiming to improve patient safety. The registry covers all healthcare providers that perform breast implant surgeries in Sweden, with about 9,936 breast implants tracked in the Västra Götaland region between 2014 and 2021.",
+        "Information": "BRIMP is the national breast implant registry. It collects data on cosmetic and reconstructive breast implant procedures, implant types, surgical methods and complications to support patient safety and quality improvement.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2014"
+        "start_date": "2014",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/brostimplantatregistret.77550.html"
     },
     {
         "name": "Kranio – Kranioregistret",
@@ -1337,7 +1514,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2023"
+        "start_date": "2023",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "LVR – Luftvägsregistret",
@@ -1354,10 +1532,13 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/luftvagsregistret.77590.html"
     },
     {
-        "name": "Nationellt kvalitetsregister för öron-, näs- och halssjukvård:",
+        "name": "Nationellt kvalitetsregister för öron-, näs- och halssjukvård",
         "registry_centre": [
             "Registercentrum Västra Götaland"
         ],
@@ -1372,7 +1553,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1997"
+        "start_date": "1997",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfororonnasochhalssjukvard.81907.html"
     },
     {
         "name": "NDR – Nationella Diabetesregistret",
@@ -1385,11 +1569,14 @@
             "Nationella",
             "Diabetes"
         ],
-        "Information": "The data collected focuses on glycaemic control, risk factors, complications, and treatment outcomes for patients with both type 1 and type 2 diabetes. It promotes evidence-based healthcare by making data available to healthcare providers for regular comparison and quality improvement efforts. The NDR is one of the largest diabetes registries in the world, covering nearly 90% of patients with diabetes in Sweden.",
+        "Information": "The National Diabetes Register collects data on diabetes care, risk factors, treatment and outcomes. It is used for quality improvement, benchmarking, follow-up and research in Swedish diabetes care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1996"
+        "start_date": "1996",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelladiabetesregistretndr.77559.html"
     },
     {
         "name": "NROK – Nationella registret för ortognatkirurgi",
@@ -1405,7 +1592,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2018"
+        "start_date": "2018",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "QregPV – Primärvårdens kvalitetsregister Västra Götaland",
@@ -1416,11 +1604,12 @@
         "search_tags": [
             "QregPV"
         ],
-        "Information": "This registry focuses on primary care for conditions like hypertension and coronary artery disease. It includes data from over 200,000 patients, helping healthcare providers track and improve treatment outcomes​.",
+        "Information": "QregPV is a regional quality registry for primary care in Vastra Gotaland. It supports systematic follow-up and quality improvement in primary care by compiling relevant clinical indicators and outcomes.",
         "category": [
-            "National quality registry"
+            "Other quality registry"
         ],
-        "start_date": "2006"
+        "start_date": "2006",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Riksfot – Svenska fotkirurgiska registret",
@@ -1434,11 +1623,14 @@
             "Riksfot",
             "surgery"
         ],
-        "Information": "The Swedish Fracture Register (SFR) tracks over 900,000 fractures and registers over 100,000 new fractures each year. It collects data on all types of fractures, both surgical and non-surgical, to improve treatment outcomes and reduce complications. The registry is used in research and clinical improvement efforts across Sweden​.",
+        "Information": "Riksfot is the Swedish foot surgery registry. It follows foot and ankle surgical procedures, patient characteristics and outcomes to support quality improvement, comparison between units and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafotkirurgiskaregistretriksfot.77564.html"
     },
     {
         "name": "SESAR – Svenska Sömnapnéregistret",
@@ -1451,11 +1643,14 @@
             "SESAR",
             "sleep apnea"
         ],
-        "Information": "SESAR focuses on tracking the diagnosis, treatment, and follow-up of patients with suspected or confirmed sleep apnea (mostly obstructive sleep apnea, OSA). The registry now includes around 120,000 patients. The number of healthcare units reporting to SESAR has grown steadily, and as of 2023, over 50 units are actively contributing data. In the last year, approximately 40,000 patient care events were registered, showing significant growth in both reporting and registry coverage​",
+        "Information": "SESAR is a national quality registry for sleep apnoea. It follows diagnosis, treatment and follow-up of patients with suspected or confirmed sleep apnoea, mainly obstructive sleep apnoea, and supports quality improvement and service development.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskasomnapneregistretsesar.77629.html"
     },
     {
         "name": "SFR – Svenska Frakturregistret",
@@ -1467,11 +1662,14 @@
             "SFR",
             "fracture"
         ],
-        "Information": "It aims to track all types of fractures treated in Sweden, with data covering fracture characteristics, patient demographics, injury types, and treatment outcomes. Both surgical and non-surgical treatments are recorded, including any subsequent reoperations or complications. The registry serves a dual purpose: improving clinical care through feedback on treatment outcomes and facilitating research. By 2023, more than 900,000 fractures had been registered, and over 100,000 new fractures are added each year​. The SFR is notable for being implemented across all 54 orthopaedic departments in Sweden, with most achieving a completeness of 75-95% in matching fractures to official health databases​.",
+        "Information": "The Swedish Fracture Register follows fractures treated in Sweden, including fracture characteristics, injury mechanisms, treatment and outcomes for both surgical and non-surgical care. It supports clinical feedback, quality improvement and research in fracture care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskafrakturregistret.77565.html"
     },
     {
         "name": "SLR – Svenska Ledprotesregistret",
@@ -1488,7 +1686,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2020"
+        "start_date": "2020",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaledprotesregistret.77595.html"
     },
     {
         "name": "SPOQ – Svenskt Pediatriskt Ortopediskt Qvalitetsregister",
@@ -1502,27 +1703,33 @@
             "child",
             "Pediatric care"
         ],
-        "Information": "Was established in 2015 and focuses on five major pediatric orthopedic conditions: hip instability (DDH), Perthes disease, slipped capital femoral epiphysis (SCFE), clubfoot (PEVA), and patellar dislocation. These conditions are significant for child orthopedics in Sweden, as untreated or delayed interventions can lead to lifelong physical impairments. The primary goal of SPOQ is to monitor and improve the quality of care by ensuring timely diagnosis and treatment. It tracks patient outcomes to prevent long-term issues like residual deformities, early-onset osteoarthritis, and the need for reoperations later in life. Data from the registry is used to evaluate treatment methods and inform clinical practice, with approximately 1 in 800 children born in Sweden being diagnosed with clubfoot​.",
+        "Information": "SPOQ is a national quality registry for paediatric orthopaedics. It focuses on conditions such as developmental dysplasia of the hip, Perthes disease, slipped capital femoral epiphysis, clubfoot and patellar dislocation, and supports timely diagnosis, treatment follow-up and quality improvement.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2015"
+        "start_date": "2015",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktpediatrisktortopedisktqvalitetsregisterspoq.77612.html"
     },
     {
         "name": "Svenska Artrosregistret",
         "registry_centre": [
             "Registercentrum Västra Götaland"
         ],
-        "url": "https://artrosregistret.registercentrum.se/",
+        "url": "https://boa.registercentrum.se/",
         "search_tags": [
             "svenska artros",
             "arthritis"
         ],
-        "Information": "It tracks data on osteoarthritis (OA) care across Sweden, focusing on non-surgical, first-line treatments like education, physical activity, and weight control. The register aims to monitor the effects of these interventions on patients' pain levels, physical activity, and overall health. As of 2023, over 225,000 patients have been registered, with data collected via questionnaires before treatment, three months after, and one year post-treatment.",
+        "Information": "Svenska Artrosregistret is a national quality registry that follows first-line osteoarthritis care and patient-reported outcomes. It is used for quality improvement, service follow-up and research in osteoarthritis care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaartrosregistret.77537.html"
     },
     {
         "name": "Svenska Hjärt- lungräddningsregistret",
@@ -1533,11 +1740,14 @@
         "search_tags": [
             "cardiopulmonary resuscitation"
         ],
-        "Information": "Plays a key role in tracking and improving cardiopulmonary resuscitation (CPR) efforts in Sweden. This registry is a vital tool in improving the chain of survival for heart attack victims, tracking critical factors such as time to intervention, quality of care, and long-term patient outcomes. Approximately 2,500 in-hospital cardiac arrests are reported annually, and out-of-hospital cases are similarly recorded, aiming for full coverage.",
+        "Information": "The Swedish Registry of Cardiopulmonary Resuscitation collects data on cardiac-arrest events and the critical links in the chain of survival, both in and outside hospital. It supports quality improvement, comparison and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1990"
+        "start_date": "1990",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahjartlungraddningsregistret.77577.html"
     },
     {
         "name": "Svenska Thoraxtransplantationsregistret",
@@ -1549,11 +1759,12 @@
             "Thoraxtransplantationsregistret",
             "transplant"
         ],
-        "Information": "The registry focuses on monitoring heart and lung transplantations performed at the only two hospitals in Sweden where these surgeries are conducted: Skånes University Hospital in Lund and Sahlgrenska University Hospital in Gothenburg. STRAX aims to systematically collect information about patients before, during, and after their transplantation. This includes data from the waiting list, details of the surgeries, and lifelong follow-ups to track the success of the transplants and manage complications. Approximately 60-70 heart and lung transplants are performed annually in Sweden.",
+        "Information": "The Swedish Thoracic Transplant Registry follows heart and lung transplantation, including waiting-list information, perioperative care and long-term follow-up. It supports quality monitoring and research in thoracic transplantation.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2018"
+        "start_date": "2018",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Svenskt Register för Rehabiliteringsmedicin",
@@ -1571,7 +1782,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2021"
+        "start_date": "2021",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktregisterforrehabiliteringsmedicin.77618.html"
     },
     {
         "name": "SWEAPS – Svenska registret för avancerad barn- och ungdomskirurgi",
@@ -1587,7 +1801,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2016"
+        "start_date": "2016",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Bipolär- och psykosregistret – Nationellt kvalitetsregister för bipolär sjukdom och schizofrenispektrumtillstånd",
@@ -1600,18 +1815,21 @@
             "bipolar",
             "psychosis"
         ],
-        "Information": "Collects and analyses data on patients with bipolar disorder and schizophrenia spectrum conditions. Currently, the registry covers around 13,000 individuals with bipolar disorder from 166 healthcare units across Sweden. It tracks variables such as the number of mood episodes, medication types, treatment outcomes, and age of onset. The data is used to improve the quality of care, evaluate new treatments, and support research in psychiatric care.",
+        "Information": "The bipolar and psychosis registry is a national quality registry for bipolar disorder and schizophrenia spectrum conditions. It collects data on disease course, medication, treatment outcomes and care processes to support quality improvement and research in psychiatric care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2004"
+        "start_date": "2004",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/bipolarochpsykosregistretbipsy.77546.html"
     },
     {
         "name": "Bättre Beroendevård",
         "registry_centre": [
             "Registercentrum Västra Götaland"
         ],
-        "url": "https://battreberoendevard.registercentrum.se/",
+        "url": "https://www.battreberoendevard.regionstockholm.se/",
         "search_tags": [
             "Beroendevård",
             "addiction"
@@ -1620,23 +1838,29 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/battreberoendevard.77545.html"
     },
     {
         "name": "Kvalitetsregister ECT",
         "registry_centre": [
             "Registercentrum Västra Götaland"
         ],
-        "url": "https://ect.registercentrum.se/",
+        "url": "https://ect.rcnorr.se/",
         "search_tags": [
             "ECT",
             "electroconvulsive therapy"
         ],
-        "Information": "The registry includes data on electroconvulsive therapy (ECT) treatments, which are used primarily for severe psychiatric conditions like depression. It has a coverage rate of approximately 96% as of 2022, with all hospitals in Sweden that provide ECT contributing data. Since 2018, it has also tracked repetitive transcranial magnetic stimulation (rTMS) treatments, covering 11 regions and with a 90% data coverage rate.",
+        "Information": "The ECT quality registry collects data on electroconvulsive therapy used mainly for severe psychiatric conditions such as depression. It also follows repetitive transcranial magnetic stimulation (rTMS) and supports quality monitoring and national comparison of these treatments.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2012"
+        "start_date": "2012",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/kvalitetsregisterect.77560.html"
     },
     {
         "name": "Q-bup – Nationellt kvalitetsregister för barn- och ungdomspsykiatri",
@@ -1649,11 +1873,12 @@
             "child psychiatry",
             "psychiatry"
         ],
-        "Information": "Focused on psychiatric care for children and adolescents across Sweden. Its primary aim is to improve the quality and equality of mental health services by collecting comprehensive data from various regions. This data includes patient demographics, diagnoses, treatments, and outcomes, providing a national benchmark for psychiatric services. As of recent reports, it had a national coverage rate of around 22%, with higher regional coverage in areas like Kalmar, Stockholm, Gävleborg, and Jämtland/Härjedalen, reaching 76%.",
+        "Information": "Q-bup is the national quality registry for child and adolescent psychiatry. It collects data on demographics, diagnoses, treatments and outcomes to support quality improvement and more equal mental health services across Sweden.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2017"
+        "start_date": "2017",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Riksät – Nationellt kvalitetsregister för ätstörningsbehandling",
@@ -1666,11 +1891,12 @@
             "psychiatry",
             "eating disorder"
         ],
-        "Information": "It initially focused on specialised eating disorder units but has since expanded to include all eating disorder care in Sweden. The registry collects detailed data on patients, such as treatment duration, outcomes, and patient satisfaction, aiming to improve care quality and follow-up of treatment effects. Currently, approximately 50 units participate across 21 regions.",
+        "Information": "Riksat is a national quality registry for eating-disorder treatment. It collects information on care, treatment, outcomes and patient experience and supports quality improvement and longitudinal follow-up.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1999"
+        "start_date": "1999",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "RättspsyK – Nationellt rättspsykiatriskt kvalitetsregister",
@@ -1683,11 +1909,14 @@
             "RättspsyK",
             "psychiatry"
         ],
-        "Information": "Tracks patients receiving forensic psychiatric care in Sweden, which involves compulsory treatment following legal decisions. The registry collects comprehensive data on 25 different indicators, including treatment plans, risk assessments, recidivism in criminal activity, use of coercive measures, and patient health status. In 2023, the registry followed up on 2,070 patients, marking its highest recorded coverage since inception.",
+        "Information": "RättspsyK is the national quality registry for forensic psychiatric care. It follows treatment plans, risk assessments, coercive measures, health status and related outcomes to support quality improvement and follow-up of compulsory forensic psychiatric care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltrattspsykiatrisktkvalitetsregisterrattspsyk.77623.html"
     },
     {
         "name": "SibeR – Svenska internetbehandlingsregistret",
@@ -1699,11 +1928,14 @@
             "internetbehandlingsregistret",
             "SibeR"
         ],
-        "Information": "Collects data on internet-based psychological treatments, including cognitive behavioural therapy (iCBT), targeting mental health conditions across psychiatry, primary care, and somatic care. By 2021, SibeR had seen increasing use, with a significant portion of the data—70%—being directly transferred from patient records, facilitating streamlined data collection. The registry covers a wide range of treatments, including recent expansions into areas such as ADHD in adults and gastrointestinal issues.",
+        "Information": "SibeR is a national quality registry for internet-delivered psychological treatment. It collects information on access to treatment, treatment processes, mental-health outcomes and completion and supports quality-driven development of digital care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2015"
+        "start_date": "2015",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskainternetbehandlingsregistretsiber.77588.html"
     },
     {
         "name": "Barnnjurregistret (BNR)",
@@ -1719,7 +1951,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "1998"
+        "start_date": "1998",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnnjurregistret.77608.html"
     },
     {
         "name": "Barnreumaregistret",
@@ -1736,7 +1971,10 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnreumaregistret.77594.html"
     },
     {
         "name": "Registret för medfödda metabola sjukdomar (RMMS)",
@@ -1748,11 +1986,14 @@
             "born",
             "RMMS"
         ],
-        "Information": "Tracks and monitors 46 rare metabolic disorders. The registry aims to improve the care of individuals with inherited metabolic diseases by gathering comprehensive data on patient demographics, diagnoses, treatments, and outcomes. The registry currently has a national coverage rate of 71% (as of 2024). RMMS is critical for standardising care across different regions in Sweden and supports ongoing research and quality improvement in healthcare for these rare conditions. Approximately 50 new cases are diagnosed annually​.",
+        "Information": "RMMS follows people with inherited metabolic disorders. It collects data on demographics, diagnoses, treatments and outcomes to support standardised care, quality improvement and research in rare metabolic disease.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registretformedfoddametabolasjukdomarrmms.77604.html"
     },
     {
         "name": "Svenska Barnhälsovårdsregistret (BHVQ)",
@@ -1769,7 +2010,8 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "PIDcare",
@@ -1784,73 +2026,91 @@
         "category": [
             "National quality registry"
         ],
-        "start_date": "2012"
+        "start_date": "2012",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforprimaraimmunbristerpidcare.77614.html"
     },
     {
         "name": "Svenskt Njurregister (SNR)",
         "registry_centre": [
             "Registercentrum Sydost"
         ],
-        "url": "https://www.medscinet.net/snr/",
+        "url": "https://www.snronline.se/",
         "search_tags": [
             "SNR",
             "Njurregister",
             "kidney"
         ],
-        "Information": "Was established to monitor and improve the quality of kidney care in Sweden, tracking various aspects of treatment for patients with chronic kidney disease, dialysis, and kidney transplants. The registry covers virtually all dialysis and transplant centres in Sweden, ensuring comprehensive national coverage. Data variables include patient demographics, treatment outcomes, transplantation statistics, and long-term survival rates. By 2023, SNR had registered over 18,300 kidney transplants, with around 6,400 patients living with a functioning transplant. Each year, the registry reports on approximately 523 transplantations and a large number of dialysis treatments.",
+        "Information": "Svenskt Njurregister follows chronic kidney disease, dialysis and kidney transplantation in Sweden. It supports clinical follow-up, quality improvement, benchmarking and research in kidney care.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1991"
+        "start_date": "1991",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktnjurregistersnr.77609.html"
     },
     {
-        "name": "Swespine",
+        "name": "Swespine – Svenska Ryggregistret",
         "registry_centre": [
             "Registercentrum Sydost"
         ],
-        "url": "http://www.swespine.se/",
+        "url": "https://www.swespine.se/",
         "search_tags": [
             "Swespine",
             "spine",
-            "spine disorders"
+            "spine disorders",
+            "Ryggregistret"
         ],
-        "Information": "It monitors spine surgeries performed across Sweden's orthopedic and neurosurgery clinics. By 2023, the registry included around 192,800 registered operations, with approximately 10,000 new spine surgeries added each year. The registry covers about 95% of the relevant clinics in Sweden, with a completeness rate of 85%, meaning a high proportion of patients who undergo spine surgery are captured.",
+        "Information": "Swespine, the Swedish Spine Registry, follows spine surgery, patient characteristics, procedures and patient-reported outcomes. It supports quality assurance, comparison of treatment results and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "1998"
+        "start_date": "1998",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaryggregistretswespine.77621.html"
     },
     {
-        "name": "Swibreg",
+        "name": "SWIBREG",
         "registry_centre": [
             "Registercentrum Sydost"
         ],
         "url": "https://www.swibreg.se/",
         "search_tags": [
-            "Swibreg"
+            "Swibreg",
+            "SWIBREG",
+            "IBD"
         ],
-        "Information": "Swibreg, the Swedish Inflammatory Bowel Disease Registry, was established to monitor and improve the care of individuals with inflammatory bowel diseases (IBD) like Crohn’s disease and ulcerative colitis. It tracks treatment outcomes, disease activity, and patient-reported quality of life across local, regional, and national levels. Swibreg currently includes data from over 64,000 registered patients.",
+        "Information": "SWIBREG is a national quality registry for inflammatory bowel disease. It follows treatment, disease activity, healthcare use and patient-reported outcomes and supports quality improvement and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2013"
+        "start_date": "2013",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforinflammatorisktarmsjukdomswibreg.77586.html"
     },
     {
         "name": "Svenska Palliativregistret",
         "registry_centre": [
             "Registercentrum Sydost"
         ],
-        "url": "https://palliativregistret.se/",
+        "url": "https://www.palliativregistret.se/",
         "search_tags": [
             "Svenska",
             "Palliativregistret",
             "pallitative"
         ],
-        "Information": "Designed to improve palliative care for patients at the end of life. The registry aims to cover all deaths in Sweden, regardless of diagnosis, age, or place of death. The registry includes data from approximately 90,000 deaths per year, contributing to continuous improvements in palliative care across various healthcare units. Variables collected include symptom management, patient and family support, and care preferences.",
+        "Information": "Svenska Palliativregistret is a national quality registry that supports systematic improvement of end-of-life care. It collects information on care processes and outcomes and provides feedback for quality improvement and research.",
         "category": [
             "National quality registry"
         ],
-        "start_date": "2005"
+        "start_date": "2005",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapalliativregistret.77633.html"
     },
     {
         "name": "Nationellt kvalitetsregister akut lymfatisk leukemi",
@@ -1865,7 +2125,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "1997"
+        "start_date": "1997",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutlymfatiskleukemiall.83492.html"
     },
     {
         "name": "Nationellt kvalitetsregister akut myeloisk leukemi (AML), inklusive akut oklassificerad leukemi (AUL)",
@@ -1880,7 +2143,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "1997"
+        "start_date": "1997",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterakutmyeloiskleukemiamlinklusiveakutoklassificeradleukemiaul.83493.html"
     },
     {
         "name": "Nationellt Kvalitetsregister för Bröstcancer NKBC",
@@ -1895,7 +2161,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancernkbc.77549.html"
     },
     {
         "name": "Svenska kvalitetsregistret för gynekologisk cancer",
@@ -1910,7 +2179,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakvalitetsregistretforgynekologiskcancer.77571.html"
     },
     {
         "name": "Nationellt kvalitetsregister hudmelanom (SweMR)",
@@ -1925,7 +2197,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2003"
+        "start_date": "2003",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterhudmelanomswemr.77580.html"
     },
     {
         "name": "Svenskt kvalitetsregister för huvud- och halscancer",
@@ -1942,7 +2217,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktkvalitetsregisterforhuvudochhalscancer.77581.html"
     },
     {
         "name": "Svenska Hypofysregistret",
@@ -1959,22 +2237,32 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2011"
+        "start_date": "2011",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskahypofysregistret.77582.html"
     },
     {
-        "name": "Nationellt kvalitetsregister kronisk lymfatisk leukemi (ALL)",
+        "name": "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
         "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
         "search_tags": [
-            "Nationellt kvalitetsregister kronisk lymfatisk leukemi (ALL)"
+            "Nationellt kvalitetsregister kronisk lymfatisk leukemi (KLL)",
+            "KLL",
+            "CLL"
         ],
         "Information": "The registry aims to collect comprehensive data on patients diagnosed with CLL, including demographic information, genetic markers, treatment approaches, and patient outcomes. Key variables tracked include treatment response, disease progression, and long-term survival rates. The registry provides insights into how different therapeutic strategies affect patient outcomes and supports ongoing clinical research.",
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2007"
+        "start_date": "2007",
+        "verification_source": "RCC",
+        "verification_url": "https://cancercentrum.se/samverkan/cancerdiagnoser/blod-lymfom-myelom/kronisk-lymfatisk-leukemi-kll/kvalitetsregister/",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterkronisklymfatiskleukemikll.84653.html"
     },
     {
         "name": "Svenska registret för cancer i lever, gallblåsa och gallvägar (SweLiv)",
@@ -1992,7 +2280,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskaregistretforcancerilevergallblasaochgallvagarsweliv.77596.html"
     },
     {
         "name": "Nationellt kvalitetsregister lymfom",
@@ -2007,7 +2298,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2000"
+        "start_date": "2000",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterlymfom.84684.html"
     },
     {
         "name": "Nationellt kvalitetsregister myelodysplastiskt syndrom",
@@ -2024,7 +2318,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelodysplastisktsyndrommds.84686.html"
     },
     {
         "name": "Nationellt kvalitetsregister myeloproliferativa sjukdomar",
@@ -2041,7 +2338,30 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyeloproliferativasjukdomarmpn.84687.html"
+    },
+    {
+        "name": "Nationellt kvalitetsregister för mastocytos",
+        "registry_centre": [
+            "Regionala Cancercentrum i Samverkan"
+        ],
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/hematologiskacancersjukdomar/mastocytos/kvalitetsregister.11775.html",
+        "search_tags": [
+            "mastocytos",
+            "mastocytosis",
+            "Nationellt kvalitetsregister för mastocytos"
+        ],
+        "Information": "The Swedish National Quality Registry for Mastocytosis collects structured data on patients with mastocytosis to support quality improvement, follow-up and research. The registry is part of the Swedish national cancer quality registry system and is supported by Regionala cancercentrum i samverkan.",
+        "category": [
+            "National cancer quality registry"
+        ],
+        "start_date": "2016",
+        "verification_source": "RCC",
+        "verification_url": "https://cancercentrum.se/utvecklingsarbeteutbildning/statistikrapporter/kvalitetsregister/ansvarsupport.8336.html",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister myelom",
@@ -2057,14 +2377,17 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2008"
+        "start_date": "2008",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistermyelom.84688.html"
     },
     {
         "name": "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/neuroendokrina-buktumorer/kvalitetsregister/",
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/neuroendokrinabuktumorer/kvalitetsregister.3525.html",
         "search_tags": [
             "Nationellt kvalitetsregister neuroendokrina buktumörer (GEP-NET)",
             "GEP-NET"
@@ -2073,7 +2396,8 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2010"
+        "start_date": "2010",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Regionalt kvalitetsregister för skelettmetastaser",
@@ -2090,7 +2414,8 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2009"
+        "start_date": "2009",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister sköldkörtelcancer",
@@ -2107,7 +2432,10 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2003"
+        "start_date": "2003",
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforskoldkortelcancer.77625.html"
     },
     {
         "name": "Svenskt kvalitetsregister för koloskopier och kolorektalcancerscreening (SveReKKS)",
@@ -2122,14 +2450,15 @@
         "category": [
             "National cancer quality registry"
         ],
-        "start_date": "2017"
+        "start_date": "2017",
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister för analcancer",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/tjocktarm-andtarm-och-anal/anal/kvalitetsregister/",
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/anal/kvalitetsregister.3263.html",
         "search_tags": [
             "Nationellt kvalitetsregister för analcancer"
         ],
@@ -2137,7 +2466,8 @@
         "start_date": "2015",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister för barncancer",
@@ -2154,7 +2484,10 @@
         "start_date": "2011",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarncancerregistretsbcr.77539.html"
     },
     {
         "name": "Nationellt kvalitetsregister för bukspottkörtelcancer (Pankreasregistret)",
@@ -2170,7 +2503,10 @@
         "start_date": "2011",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbukspottkortelcancerpankreasregistret.77552.html"
     },
     {
         "name": "Nationella Kvalitetsregistret för Cervixcancerprevention (NKCx)",
@@ -2185,7 +2521,10 @@
         "start_date": "1999",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregistretforcervixcancerpreventionnkcx.77597.html"
     },
     {
         "name": "Nationellt kvalitetsregister för hjärntumörer och centrala nervsystemet",
@@ -2202,7 +2541,10 @@
         "start_date": "2009",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforhjarntumorerochcentralanervsystemet.77575.html"
     },
     {
         "name": "Nationellt kvalitetsregister för KML (kronisk myeloisk leukemi)",
@@ -2218,7 +2560,10 @@
         "start_date": "2002",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforkroniskmyeloiskleukemikml.84685.html"
     },
     {
         "name": "Nationellt kvalitetsregister för lungcancer",
@@ -2234,7 +2579,10 @@
         "start_date": "2002",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforlungcancer.77599.html"
     },
     {
         "name": "Nationellt kvalitetsregister för matstrups- och magsäckscancer (NREV)",
@@ -2251,7 +2599,10 @@
         "start_date": "2007",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterformatstrupsochmagsackscancernrev.77553.html"
     },
     {
         "name": "Nationellt kvalitetsregister för njurcancer",
@@ -2267,14 +2618,17 @@
         "start_date": "2005",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfornjurcancer.77607.html"
     },
     {
         "name": "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
-        "url": "https://cancercentrum.se/samverkan/vara-uppdrag/prevention-och-tidig-upptackt/prostatacancertestning/kvalitetsregister/",
+        "url": "https://cancercentrum.se/preventiontidigupptackt/screeningochtestning/prostatacancertestning/kvalitetsregister.7547.html",
         "search_tags": [
             "Nationella kvalitetsregistret för organiserad prostatacancertestning (SweOPT)",
             "prostate cancer",
@@ -2284,14 +2638,15 @@
         "start_date": "2023",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister för sarkom",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
-        "url": "https://cancercentrum.se/samverkan/cancerdiagnoser/sarkom/kvalitetsregister/",
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/sarkom/skelettochmjukdelssarkom/kvalitetsregister.3495.html",
         "search_tags": [
             "Nationellt kvalitetsregister för sarkom",
             "ewings sarcoma",
@@ -2301,7 +2656,8 @@
         "start_date": "2009",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Nationellt kvalitetsregister för testikelcancer seminom",
@@ -2317,7 +2673,10 @@
         "start_date": "2000",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterfortestikelcancerseminom.77630.html"
     },
     {
         "name": "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
@@ -2329,11 +2688,14 @@
             "Nationellt kvalitetsregister för tjock- och ändtarmscancer",
             "colorectal cancer"
         ],
-        "Information": "It collects comprehensive data on patients diagnosed with colorectal cancer, focusing on diagnosis, surgical treatments, radiotherapy, chemotherapy, and outcomes. The aim is to improve treatment protocols and outcomes by comparing data across hospitals and regions. The registry covers all major hospitals in Sweden and ensures complete national coverage. As of recent years, it tracks thousands of new cases annually, with around 6,000 new patients added each year.",
+        "Information": "The national colorectal cancer registry collects data on diagnosis, surgical treatment, radiotherapy, chemotherapy and outcomes. It supports comparison across hospitals and regions, quality improvement and research in colorectal cancer care.",
         "start_date": "2007",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskakolorektalcancerregistretscrcr.77631.html"
     },
     {
         "name": "Nationellt kvalitetsregister för urinblåsecancer",
@@ -2345,11 +2707,14 @@
             "Nationellt kvalitetsregister för urinblåsecancer",
             "bladder cancer"
         ],
-        "Information": "It collects detailed information on patients diagnosed with bladder cancer, including tumour stage, grade, treatment methods (such as surgery, radiotherapy, chemotherapy, or immunotherapy), and long-term outcomes. The primary aim is to improve clinical practice by tracking treatments and outcomes across all hospitals in Sweden, ensuring uniform quality standards. The registry also supports research by providing data for evaluating treatment effectiveness. Annually, around 2,000 new bladder cancer cases are registered.",
+        "Information": "The national bladder cancer registry collects information on tumour stage and grade, treatment such as surgery, radiotherapy, chemotherapy or immunotherapy, and long-term outcomes. It supports uniform quality standards, clinical follow-up and research.",
         "start_date": "1997",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforurinblasecancer.77554.html"
     },
     {
         "name": "Nationella prostatacancerregistret (NPCR)",
@@ -2365,23 +2730,29 @@
         "start_date": "1987",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationellaprostatacancerregistretnpcr.77615.html"
     },
     {
         "name": "Nationellt kvalitetsregister peniscancer (NPECR)",
         "registry_centre": [
             "Regionala Cancercentrum i Samverkan"
         ],
-        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/penis.8266.html",
+        "url": "https://cancercentrum.se/diagnosbehandling/cancerdiagnoser/penis/kvalitetsregister.3518.html",
         "search_tags": [
             "Nationellt kvalitetsregister för peniscancer",
             "penis cancer"
         ],
-        "Information": "NPECR monitors penile cancer care in Sweden, and more than 3,900 patients are included. Over the past six years, the coverage rate has been 88% compared to the Swedish Cancer Register, ensuring that the data is nationwide and population based. The register collects information on disease incidence, diagnostics, tumor stage distribution, morphological classification, treatment, surgical complications, and follow-up. Since 2015, it also includes patient-reported outcome and experience measures and referrals to the national center.",
+        "Information": "The national penile cancer registry includes newly diagnosed invasive and non-invasive penile cancer and records information on diagnosis, staging, treatment, waiting times and follow-up. It also supports patient-reported outcome and experience measures.",
         "start_date": "2000",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltregisterforpeniscancer.77613.html"
     },
     {
         "name": "Nationellt kvalitetsregister för mammografiscreening (NKM)",
@@ -2397,7 +2768,10 @@
         "start_date": "about 2020",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforbrostcancerscreeningnkb.77602.html"
     },
     {
         "name": "Svenskt bråckregister",
@@ -2413,7 +2787,10 @@
         "start_date": "1992",
         "category": [
             "National quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11",
+        "metadata_source": "SKR",
+        "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svensktbrackregister.77598.html"
     },
     {
         "name": "Nationellt onkogenetiskt kvalitetsregister (NOGA)",
@@ -2428,7 +2805,8 @@
         "start_date": "2021",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11"
     },
     {
         "name": "Register för cancerläkemedel",
@@ -2446,6 +2824,7 @@
         "start_date": "2018",
         "category": [
             "National cancer quality registry"
-        ]
+        ],
+        "last_verified": "2026-08-11"
     }
 ]

--- a/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
+++ b/next-app/src/assets/Kvalitetsregister_geo_dates_02.09.2024.json
@@ -302,8 +302,7 @@
     "category": [
       "Other quality registry"
     ],
-    "start_date": "1998",
-    "last_verified": "2026-08-11"
+    "start_date": "1998"
   },
   {
     "name": "Lungfibrosregistret",
@@ -1238,7 +1237,6 @@
       "National quality registry"
     ],
     "start_date": "2009",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforpatientermedsvarlaktasarrikssar.77628.html"
   },
@@ -1867,9 +1865,9 @@
   {
     "name": "Q-bup – Nationellt kvalitetsregister för barn- och ungdomspsykiatri",
     "registry_centre": [
-      "Registercentrum Västra Götaland"
+      "Kvalitetsregistercentrum Stockholm"
     ],
-    "url": "https://qbup.registercentrum.se/",
+    "url": "https://www.qbup.slso.regionstockholm.se/",
     "search_tags": [
       "peadiatric care",
       "child psychiatry",
@@ -1880,7 +1878,7 @@
       "National quality registry"
     ],
     "start_date": "2017",
-    "last_verified": "2026-08-11"
+    "last_verified": "2026-08-12"
   },
   {
     "name": "Riksät – Nationellt kvalitetsregister för ätstörningsbehandling",
@@ -1954,7 +1952,6 @@
       "National quality registry"
     ],
     "start_date": "1998",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnnjurregistret.77608.html"
   },
@@ -1974,7 +1971,6 @@
       "National quality registry"
     ],
     "start_date": "2009",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskabarnreumaregistret.77594.html"
   },
@@ -1993,7 +1989,6 @@
       "National quality registry"
     ],
     "start_date": "2013",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/registretformedfoddametabolasjukdomarrmms.77604.html"
   },
@@ -2012,8 +2007,7 @@
     "category": [
       "National quality registry"
     ],
-    "start_date": "2013",
-    "last_verified": "2026-08-11"
+    "start_date": "2013"
   },
   {
     "name": "PIDcare",
@@ -2029,7 +2023,6 @@
       "National quality registry"
     ],
     "start_date": "2012",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/nationelltkvalitetsregisterforprimaraimmunbristerpidcare.77614.html"
   },
@@ -2110,7 +2103,6 @@
       "National quality registry"
     ],
     "start_date": "2005",
-    "last_verified": "2026-08-11",
     "metadata_source": "SKR",
     "metadata_url": "https://kunskapsstyrningvard.se/kunskapsstyrningvard/datauppfoljningochanalys/kvalitetsregister/hittakvalitetsregister/registerarkiv/svenskapalliativregistret.77633.html"
   },

--- a/next-app/src/components/QualityRegistryCard.tsx
+++ b/next-app/src/components/QualityRegistryCard.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Safe } from "@/components/common/SafeContent";
+import { MetadataLink } from "@/components/common/MetadataLink";
 import { IRegistrySource } from "@/interfaces/types";
+import { isSameDestination } from "@/lib/url-utils";
 
 /**
  * QualityRegistryCard Component
@@ -30,18 +32,6 @@ interface QualityRegistryCardProps {
   organisationLinks: Record<string, string>;
 }
 
-/** Compare URLs ignoring trailing slash, whitespace, and host casing. */
-function normalizeUrl(url?: string): string {
-  if (!url) return "";
-  const trimmed = url.trim();
-  try {
-    const parsed = new URL(trimmed);
-    return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, "").toLowerCase();
-  } catch {
-    return trimmed.replace(/\/+$/, "").toLowerCase();
-  }
-}
-
 export const QualityRegistryCard = ({
   registry,
   searchTerms,
@@ -55,11 +45,15 @@ export const QualityRegistryCard = ({
   );
   const hasSearch = searchTerms.length > 0;
 
-  const showMetadata =
-    !!registry.metadata_url &&
-    (registry.metadata_source === "SKR" ||
-      registry.metadata_source === "RCC") &&
-    normalizeUrl(registry.metadata_url) !== normalizeUrl(registry.url);
+  // Show the catalogue link only when it adds something: a source label, and a
+  // destination that is not just the registry's own site again. Deliberately
+  // not restricted to a known set of sources — the data decides, so adding a
+  // catalogue is a data change rather than a change here.
+  const metadataUrl =
+    registry.metadata_source &&
+    !isSameDestination(registry.metadata_url, registry.url)
+      ? registry.metadata_url
+      : undefined;
 
   return (
     <article
@@ -103,26 +97,14 @@ export const QualityRegistryCard = ({
             allowedAttr={["class"]}
             className="mb-3"
           />
-          {showMetadata && (
+          {metadataUrl && (
             <div className="mb-3">
-              <Safe.Url
-                url={registry.metadata_url!}
-                className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium rounded-full text-black bg-[#649ED2] hover:opacity-90 self-start transition-opacity duration-100 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                aria-label={`View Metadata: ${registry.metadata_source} for ${registry.name} (opens in new tab)`}
+              <MetadataLink
+                href={metadataUrl}
+                ariaLabel={`View metadata for ${registry.name} at ${registry.metadata_source} (opens in new tab)`}
               >
                 Metadata: {registry.metadata_source}
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="20"
-                  height="20.092"
-                  className="shrink-0"
-                  aria-hidden="true"
-                  role="presentation"
-                >
-                  <path d="m12 0 2.561 2.537-6.975 6.976 2.828 2.828 6.988-6.988L20 7.927 19.998 0H12z" />
-                  <path d="M9 4.092v-2H0v18h18v-9h-2v7H2v-14h7z" />
-                </svg>
-              </Safe.Url>
+              </MetadataLink>
             </div>
           )}
           <dl

--- a/next-app/src/components/QualityRegistryCard.tsx
+++ b/next-app/src/components/QualityRegistryCard.tsx
@@ -30,6 +30,18 @@ interface QualityRegistryCardProps {
   organisationLinks: Record<string, string>;
 }
 
+/** Compare URLs ignoring trailing slash, whitespace, and host casing. */
+function normalizeUrl(url?: string): string {
+  if (!url) return "";
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    return `${parsed.host}${parsed.pathname}`.replace(/\/+$/, "").toLowerCase();
+  } catch {
+    return trimmed.replace(/\/+$/, "").toLowerCase();
+  }
+}
+
 export const QualityRegistryCard = ({
   registry,
   searchTerms,
@@ -43,6 +55,12 @@ export const QualityRegistryCard = ({
   );
   const hasSearch = searchTerms.length > 0;
 
+  const showMetadata =
+    !!registry.metadata_url &&
+    (registry.metadata_source === "SKR" ||
+      registry.metadata_source === "RCC") &&
+    normalizeUrl(registry.metadata_url) !== normalizeUrl(registry.url);
+
   return (
     <article
       key={registry.name}
@@ -53,6 +71,7 @@ export const QualityRegistryCard = ({
       <Card>
         <CardHeader className="bg-muted">
           <CardTitle className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            {/* Website / official registry link (primary) */}
             <Safe.Url
               url={registry.url}
               className="text-xl text-primary hover:underline"
@@ -84,6 +103,28 @@ export const QualityRegistryCard = ({
             allowedAttr={["class"]}
             className="mb-3"
           />
+          {showMetadata && (
+            <div className="mb-3">
+              <Safe.Url
+                url={registry.metadata_url!}
+                className="inline-flex items-center gap-2 px-3 py-1 text-sm font-medium rounded-full text-black bg-[#649ED2] hover:opacity-90 self-start transition-opacity duration-100 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2"
+                aria-label={`View Metadata: ${registry.metadata_source} for ${registry.name} (opens in new tab)`}
+              >
+                Metadata: {registry.metadata_source}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20.092"
+                  className="shrink-0"
+                  aria-hidden="true"
+                  role="presentation"
+                >
+                  <path d="m12 0 2.561 2.537-6.975 6.976 2.828 2.828 6.988-6.988L20 7.927 19.998 0H12z" />
+                  <path d="M9 4.092v-2H0v18h18v-9h-2v7H2v-14h7z" />
+                </svg>
+              </Safe.Url>
+            </div>
+          )}
           <dl
             className="mt-3 flex flex-wrap gap-2"
             aria-label="Registry details"

--- a/next-app/src/components/QualityRegistryCard.tsx
+++ b/next-app/src/components/QualityRegistryCard.tsx
@@ -48,11 +48,13 @@ export const QualityRegistryCard = ({
   // Show the catalogue link only when it adds something: a source label, and a
   // destination that is not just the registry's own site again. Deliberately
   // not restricted to a known set of sources — the data decides, so adding a
-  // catalogue is a data change rather than a change here.
-  const metadataUrl =
+  // catalogue is a data change rather than a change here. Narrowed into one
+  // object so both fields stay type-checked at the call site.
+  const metadata =
     registry.metadata_source &&
+    registry.metadata_url &&
     !isSameDestination(registry.metadata_url, registry.url)
-      ? registry.metadata_url
+      ? { source: registry.metadata_source, url: registry.metadata_url }
       : undefined;
 
   return (
@@ -97,14 +99,13 @@ export const QualityRegistryCard = ({
             allowedAttr={["class"]}
             className="mb-3"
           />
-          {metadataUrl && (
+          {metadata && (
             <div className="mb-3">
               <MetadataLink
-                href={metadataUrl}
-                ariaLabel={`View metadata for ${registry.name} at ${registry.metadata_source} (opens in new tab)`}
-              >
-                Metadata: {registry.metadata_source}
-              </MetadataLink>
+                href={metadata.url}
+                source={metadata.source}
+                resourceName={registry.name}
+              />
             </div>
           )}
           <dl

--- a/next-app/src/components/common/MetadataLink.tsx
+++ b/next-app/src/components/common/MetadataLink.tsx
@@ -1,0 +1,46 @@
+import { Safe } from "@/components/common/SafeContent";
+
+/**
+ * Pill-shaped link to an external metadata/catalogue record for a data source
+ * (e.g. an SND study page, or an SKR quality-registry archive entry).
+ *
+ * Shared by the quality-registries and swedish-research-cohorts pages so the
+ * badge styling, external-link icon and accessible wording stay identical. The
+ * href goes through `Safe.Url`, so these externally-sourced URLs are held to an
+ * http/https allowlist and unsafe schemes collapse to "#".
+ */
+interface MetadataLinkProps {
+  /** Destination URL. Sanitised before it reaches the DOM. */
+  href: string;
+  /** Full accessible name, e.g. `View SND metadata for X (opens in new tab)`. */
+  ariaLabel: string;
+  /** Visible badge label. */
+  children: React.ReactNode;
+}
+
+export const MetadataLink = ({
+  href,
+  ariaLabel,
+  children,
+}: MetadataLinkProps) => (
+  <Safe.Url
+    url={href}
+    aria-label={ariaLabel}
+    className="inline-flex w-fit items-center gap-2 rounded-full bg-metadata px-3 py-1 text-sm font-medium text-metadata-foreground transition-opacity duration-100 hover:opacity-90 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2"
+  >
+    {children}
+    {/* External-link glyph. Inherits the label colour and scales with it. */}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20.092"
+      width="20"
+      height="20.092"
+      fill="currentColor"
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <path d="m12 0 2.561 2.537-6.975 6.976 2.828 2.828 6.988-6.988L20 7.927 19.998 0H12z" />
+      <path d="M9 4.092v-2H0v18h18v-9h-2v7H2v-14h7z" />
+    </svg>
+  </Safe.Url>
+);

--- a/next-app/src/components/common/MetadataLink.tsx
+++ b/next-app/src/components/common/MetadataLink.tsx
@@ -4,31 +4,32 @@ import { Safe } from "@/components/common/SafeContent";
  * Pill-shaped link to an external metadata/catalogue record for a data source
  * (e.g. an SND study page, or an SKR quality-registry archive entry).
  *
- * Shared by the quality-registries and swedish-research-cohorts pages so the
- * badge styling, external-link icon and accessible wording stay identical. The
- * href goes through `Safe.Url`, so these externally-sourced URLs are held to an
+ * Shared by the quality-registries and swedish-research-cohorts pages. The
+ * label and the accessible name are both derived from `source` here rather than
+ * passed in, so the two pages cannot drift apart in wording again. The href
+ * goes through `Safe.Url`, so these externally-sourced URLs are held to an
  * http/https allowlist and unsafe schemes collapse to "#".
  */
 interface MetadataLinkProps {
   /** Destination URL. Sanitised before it reaches the DOM. */
   href: string;
-  /** Full accessible name, e.g. `View SND metadata for X (opens in new tab)`. */
-  ariaLabel: string;
-  /** Visible badge label. */
-  children: React.ReactNode;
+  /** Catalogue the record lives in, e.g. `SND` or `SKR`. Used in the label. */
+  source: string;
+  /** Name of the registry or cohort, used to disambiguate the link for screen readers. */
+  resourceName: string;
 }
 
 export const MetadataLink = ({
   href,
-  ariaLabel,
-  children,
+  source,
+  resourceName,
 }: MetadataLinkProps) => (
   <Safe.Url
     url={href}
-    aria-label={ariaLabel}
+    aria-label={`View ${source} metadata for ${resourceName} (opens in new tab)`}
     className="inline-flex w-fit items-center gap-2 rounded-full bg-metadata px-3 py-1 text-sm font-medium text-metadata-foreground transition-opacity duration-100 hover:opacity-90 focus:outline-hidden focus:ring-2 focus:ring-primary focus:ring-offset-2"
   >
-    {children}
+    {source} Metadata
     {/* External-link glyph. Inherits the label colour and scales with it. */}
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/next-app/src/components/common/SafeContent.tsx
+++ b/next-app/src/components/common/SafeContent.tsx
@@ -43,8 +43,9 @@ export function SafeText({
 }: SafeTextProps) {
   const sanitizedText = sanitizeText(text, config);
 
+  // Spread first, for consistency with SafeUrl and SafeHTML.
   return (
-    <Component className={className} {...props}>
+    <Component {...props} className={className}>
       {sanitizedText}
     </Component>
   );
@@ -64,13 +65,19 @@ export function SafeUrl({
 }: SafeUrlProps) {
   const sanitizedUrl = sanitizeURL(url, config);
 
+  // `{...props}` is spread FIRST so the security-relevant attributes below
+  // always win. Passing `href` is a type error today (SafeUrlProps has no
+  // `href`), but ordering makes that structural rather than a side effect of
+  // the props interface happening to stay narrow — and hyphenated JSX
+  // attributes (aria-*, data-*) bypass excess-property checking, so `props` is
+  // not as closed as it looks.
   return (
     <a
+      {...props}
       href={sanitizedUrl}
       target={target}
       rel={rel}
       className={className}
-      {...props}
     >
       {children}
     </a>
@@ -89,11 +96,14 @@ export function SafeHTML({
 }: SafeHTMLProps) {
   const sanitizedHTML = sanitizeHTML(html, allowedTags, allowedAttr);
 
+  // Spread first: `dangerouslySetInnerHTML` must not be overridable by a
+  // caller-supplied prop, or unsanitised markup could replace the sanitised
+  // payload. See the note in SafeUrl.
   return (
     <div
+      {...props}
       className={className}
       dangerouslySetInnerHTML={{ __html: sanitizedHTML }}
-      {...props}
     />
   );
 }

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -42,6 +42,12 @@ export interface IRegistrySource {
   metadata_source?: string;
   /** URL for the primary metadata/catalogue page. Must differ from `url`. */
   metadata_url?: string;
+  /**
+   * ISO date (YYYY-MM-DD) on which this entry's links and description were last
+   * checked against the registry's own site. Provenance only — not rendered;
+   * the page shows a single site-wide date via `<LastUpdated />`.
+   */
+  last_verified?: string;
 }
 
 export const filters: IRegistryFilters = {

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -43,9 +43,13 @@ export interface IRegistrySource {
   /** URL for the primary metadata/catalogue page. Must differ from `url`. */
   metadata_url?: string;
   /**
-   * ISO date (YYYY-MM-DD) on which this entry's links and description were last
-   * checked against the registry's own site. Provenance only — not rendered;
-   * the page shows a single site-wide date via `<LastUpdated />`.
+   * ISO date (YYYY-MM-DD) on which *this* registry's link was confirmed
+   * reachable and its description checked against the registry's own site.
+   * Omit when that could not be confirmed — an absent value means "unverified",
+   * so do not backfill it for rows whose link is broken.
+   *
+   * Provenance only; not rendered. The page shows a single site-wide date via
+   * `<LastUpdated />`.
    */
   last_verified?: string;
 }

--- a/next-app/src/interfaces/types.ts
+++ b/next-app/src/interfaces/types.ts
@@ -35,6 +35,13 @@ export interface IRegistrySource {
   registry_centre: string[];
   category: string[];
   search_tags: string[];
+  /**
+   * Primary external metadata/catalogue source, typically "SKR" or "RCC".
+   * Omit when there is no separate catalogue page (e.g. metadata URL equals official URL).
+   */
+  metadata_source?: string;
+  /** URL for the primary metadata/catalogue page. Must differ from `url`. */
+  metadata_url?: string;
 }
 
 export const filters: IRegistryFilters = {

--- a/next-app/src/lib/url-utils.test.ts
+++ b/next-app/src/lib/url-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { isSameDestination } from "./url-utils";
+
+describe("isSameDestination", () => {
+  it("treats trailing-slash-only differences as the same page", () => {
+    expect(isSameDestination("https://x.se/reg", "https://x.se/reg/")).toBe(
+      true,
+    );
+  });
+
+  it("ignores protocol and host casing", () => {
+    expect(isSameDestination("http://X.se/reg", "https://x.se/reg")).toBe(true);
+  });
+
+  it("ignores a leading www.", () => {
+    expect(isSameDestination("https://www.x.se/reg", "https://x.se/reg")).toBe(
+      true,
+    );
+  });
+
+  it("treats paths differing only by case as different pages", () => {
+    expect(isSameDestination("https://x.se/Reg", "https://x.se/reg")).toBe(
+      false,
+    );
+  });
+
+  it("treats a differing query string as a different page", () => {
+    expect(isSameDestination("https://x.se/p", "https://x.se/p?id=7")).toBe(
+      false,
+    );
+    expect(
+      isSameDestination("https://x.se/p?id=7", "https://x.se/p?id=8"),
+    ).toBe(false);
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(isSameDestination("  https://x.se/reg  ", "https://x.se/reg")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when either URL is missing", () => {
+    expect(isSameDestination(undefined, "https://x.se")).toBe(false);
+    expect(isSameDestination("https://x.se", undefined)).toBe(false);
+    expect(isSameDestination("", "")).toBe(false);
+  });
+
+  it("falls back to string comparison for unparseable input", () => {
+    expect(isSameDestination("not a url", "not a url")).toBe(true);
+    expect(isSameDestination("not a url", "other junk")).toBe(false);
+  });
+});

--- a/next-app/src/lib/url-utils.ts
+++ b/next-app/src/lib/url-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * URL helpers for comparing the externally-sourced links in the data-source
+ * pages. The registry and cohort JSON assets are curated by hand, so the same
+ * page often appears under slightly different spellings (http vs https, a
+ * stray `www.`, a trailing slash).
+ */
+
+/**
+ * Reduce a URL to a comparable identity: host (without a leading `www.`) plus
+ * path plus query. Protocol, host casing and a trailing slash are ignored
+ * because none of them change which page is served. Path and query casing are
+ * preserved — most web servers treat those as significant.
+ */
+function destinationKey(url: string): string {
+  const trimmed = url.trim();
+
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.host.toLowerCase().replace(/^www\./, "");
+    const path = parsed.pathname.replace(/\/+$/, "");
+    return `${host}${path}${parsed.search}`;
+  } catch {
+    // Not an absolute URL. The data is externally sourced, so rather than
+    // guessing a scheme, compare verbatim minus a trailing slash.
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+/**
+ * True when both URLs resolve to the same page. Used to suppress a secondary
+ * link that would only repeat the primary one. Missing input is never "the
+ * same": an absent URL cannot duplicate anything.
+ */
+export function isSameDestination(a?: string, b?: string): boolean {
+  if (!a?.trim() || !b?.trim()) return false;
+  return destinationKey(a) === destinationKey(b);
+}


### PR DESCRIPTION
https://scilifelab.atlassian.net/browse/TP-805

### **Update Quality Registries and add metadata links**


This PR updates the Quality Registries page with improved registry information and introduces a new Metadata button for linking to authoritative external registry sources.

### Main changes

- Added a Metadata button to quality registry entries, linking to relevant authoritative sources such as SKR and RCC
- Updated the related component and TypeScript interface/data structure to support metadata source and URL fields
- Metadata links are only displayed when they provide a useful source distinct from the registry's main website
- Updated registry classifications to better distinguish national, national cancer, and other quality registries
- Added missing registries, including the National Quality Registry for Mastocytosis
- Updated the rare-disease registry information to RaraSwed
- Corrected registry names and abbreviations, including KLL
- Updated outdated descriptions and removed or revised time-sensitive statistics where appropriate
- Reviewed and corrected inconsistent registry information and links
- Kept the existing filters and overall page structure unchanged

The page now contains 146 quality registries, with more consistent classifications and descriptions and clearer links to authoritative metadata sources.